### PR TITLE
Split server/index.ts into createApp & httpServer parts

### DIFF
--- a/@app/server/src/createApp.ts
+++ b/@app/server/src/createApp.ts
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+import * as express from "express";
+import { sanitiseEnv } from "./utils";
+import * as middleware from "./middleware";
+
+export default async () => {
+  sanitiseEnv();
+
+  const isTest = process.env.NODE_ENV === "test";
+  const isDev = process.env.NODE_ENV === "development";
+
+  /*
+   * Our Express server
+   */
+  const app = express();
+
+  /*
+   * When we're using websockets, we may want them to have access to
+   * sessions/etc for authentication.
+   */
+  const websocketMiddlewares: express.RequestHandler[] = [];
+  app.set("websocketMiddlewares", websocketMiddlewares);
+
+  /*
+   * installs shutdownActions so it's available
+   * inside other middleware and after it
+   */
+  const shutdownActions: (() => any)[] = [];
+  app.set("shutdownActions", shutdownActions);
+
+  /*
+   * Middleware is installed from the /server/middleware directory. These
+   * helpers may augment the express app with new settings and/or install
+   * express middleware. These helpers may be asynchronous, but they should
+   * operate very rapidly to enable quick as possible server startup.
+   */
+  await middleware.installDatabasePools(app);
+  await middleware.installHelmet(app);
+  await middleware.installSession(app);
+  await middleware.installPassport(app);
+  await middleware.installLogging(app);
+  // These are our assets: images/etc; served out of the /client/public folder
+  await middleware.installSharedStatic(app);
+  if (isTest || isDev) {
+    await middleware.installCypressServerCommand(app);
+  }
+  await middleware.installPostGraphile(app);
+
+  /*
+   * Error handling middleware
+   */
+  await middleware.installErrorHandler(app);
+
+  return app;
+};

--- a/@app/server/src/index.ts
+++ b/@app/server/src/index.ts
@@ -1,36 +1,18 @@
 #!/usr/bin/env node
 /* eslint-disable no-console */
-import * as express from "express";
 import chalk from "chalk";
 import { createServer } from "http";
-import { sanitiseEnv } from "./utils";
-import * as middleware from "./middleware";
-
+import createApp from "./createApp";
+import installNext from "./middleware/installNext";
 // @ts-ignore
 const packageJson = require("../../../package.json");
 
 async function main() {
-  sanitiseEnv();
-
-  const isTest = process.env.NODE_ENV === "test";
   const isDev = process.env.NODE_ENV === "development";
 
-  /*
-   * Our Express server
-   */
-  const app = express();
+  const app = await createApp();
 
-  /*
-   * For a clean nodemon shutdown, we need to close all our sockets otherwise
-   * we might not come up cleanly again (inside nodemon).
-   */
-  const shutdownActions: (() => any)[] = [];
-  app.set("shutdownActions", shutdownActions);
-
-  if (isDev) {
-    shutdownActions.push(() => require("inspector").close());
-  }
-
+  await installNext(app);
   /*
    * Getting access to the HTTP server directly means that we can do things
    * with websockets if we need to (e.g. GraphQL subscriptions).
@@ -38,36 +20,10 @@ async function main() {
   const httpServer = createServer(app);
   app.set("httpServer", httpServer);
 
-  /*
-   * When we're using websockets, we may want them to have access to
-   * sessions/etc for authentication.
-   */
-  const websocketMiddlewares: express.RequestHandler[] = [];
-  app.set("websocketMiddlewares", websocketMiddlewares);
-
-  /*
-   * Middleware is installed from the /server/middleware directory. These
-   * helpers may augment the express app with new settings and/or install
-   * express middleware. These helpers may be asynchronous, but they should
-   * operate very rapidly to enable quick as possible server startup.
-   */
-  await middleware.installDatabasePools(app);
-  await middleware.installHelmet(app);
-  await middleware.installSession(app);
-  await middleware.installPassport(app);
-  await middleware.installLogging(app);
-  // These are our assets: images/etc; served out of the /@app/server/public folder (if present)
-  await middleware.installSharedStatic(app);
-  if (isTest || isDev) {
-    await middleware.installCypressServerCommand(app);
+  const shutdownActions = app.get("shutdownActions");
+  if (isDev) {
+    shutdownActions.push(() => require("inspector").close());
   }
-  await middleware.installPostGraphile(app);
-  await middleware.installNext(app);
-
-  /*
-   * Error handling middleware
-   */
-  await middleware.installErrorHandler(app);
 
   // And finally, we open the listen port
   const PORT = parseInt(process.env.PORT || "", 10) || 3000;
@@ -100,10 +56,15 @@ async function main() {
   });
 
   // Nodemon SIGUSR2 handling
+  /*
+   * For a clean nodemon shutdown, we need to close all our sockets otherwise
+   * we might not come up cleanly again (inside nodemon).
+   */
   shutdownActions.push(() => httpServer.close());
+
   async function gracefulShutdown(callback: () => void) {
     try {
-      await Promise.all(shutdownActions.map(fn => fn()));
+      await Promise.all(shutdownActions.map((fn: any) => fn()));
     } finally {
       // 250ms of sleep before finally shutting down, give things a moment to
       // clear up.


### PR DESCRIPTION
Needed for nuxt.js so it's possible to hook postgraphile module into
running express/connect instance that nuxt.js already created and
manages