### PR TITLE
Write `COMPOSE_PROJECT_NAME` into `.env` even if empty

### DIFF
--- a/scripts/setup.js
+++ b/scripts/setup.js
@@ -237,14 +237,13 @@ async function updateDotenv(answers) {
 # Client Secret:`
   );
 
-  if (projectName) {
-    add(
-      "COMPOSE_PROJECT_NAME",
-      projectName,
-      `\
+  add(
+    "COMPOSE_PROJECT_NAME",
+
+    projectName ? projectName : "", // at least set COMPOSE_PROJECT_NAME so it's easier to find/set manually later
+    `\
 # The name of the folder you cloned graphile-starter to (so we can run docker-compose inside a container):`
-    );
-  }
+  );
 
   data = data.trim() + "\n";
 


### PR DESCRIPTION
So we can run `yarn setup` from inside container without `exit` -> `docker-compose down` -> `yarn docker setup` all the time