### PR TITLE
In-process optimisation for server-side requests

### DIFF
--- a/@app/client/src/lib/withApollo.ts
+++ b/@app/client/src/lib/withApollo.ts
@@ -34,7 +34,7 @@ export default withApollo(
         ? new GraphileLink({
             req,
             res,
-            graphile: req.app.get("graphile"),
+            postgraphileMiddleware: req.app.get("postgraphileMiddleware"),
           })
         : new HttpLink({
             uri: `${ROOT_URL}/graphql`,

--- a/@app/server/src/middleware/installPostGraphile.ts
+++ b/@app/server/src/middleware/installPostGraphile.ts
@@ -263,11 +263,11 @@ export default function installPostGraphile(app: Express) {
       rootPgPool,
     })
   );
-  app.use((req, _res, next) => {
-    req.app.set("graphile", middleware);
-    next();
-  });
+
+  app.set("postgraphileMiddleware", middleware);
+
   app.use(middleware);
+
   const httpServer = getHttpServer(app);
   if (httpServer) {
     enhanceHttpServerWithSubscriptions(httpServer, middleware);


### PR DESCRIPTION
Implemented `GraphileLink` which performs all server-side requests inside the server process directly.

This eliminates any extraneous HTTP overhead.