### PR TITLE
chore: enable proseWrap in prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     ]
   },
   "prettier": {
-    "trailingComma": "es5"
+    "trailingComma": "es5",
     "proseWrap": "always"
   },
   "jest": {


### PR DESCRIPTION
Add `proseWrap: always` to prettier config