### PR TITLE
Fix docker-compose port specification on modern versions of docker.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,11 +99,11 @@ services:
       - default
     ports:
       # The main server
-      - "5678:5678"
+      - "5678"
       # Node `--inspect=...` port numbers for debugging
-      - "9678:9678"
-      - "9876:9876"
-      - "9757:9757"
+      - "9678"
+      - "9876"
+      - "9757"
     depends_on:
       - db
     # Overrides default command so things don't shut down after the process ends.


### PR DESCRIPTION
Thanks for the excellent work on this project. This was required to get the containers to launch correctly on my version of docker for mac downloaded today at docker hub. I haven't tested this across other platforms but without it it was complaining about already used ports. 

For example: 
ERROR: for starter_dev_1  Cannot start service dev: driver failed programming external connectivity on endpoint starter_dev_1 (86c8344f8e3db2753ae51c99d7cc9a7b1da891d85bb896d54819b0669820629b): Bind for 0.0.0.0:9757 failed: port is already allocated

ERROR: for dev  Cannot start service dev: driver failed programming external connectivity on endpoint starter_dev_1 (86c8344f8e3db2753ae51c99d7cc9a7b1da891d85bb896d54819b0669820629b): Bind for 0.0.0.0:9757 failed: port is already allocated
