### PR TITLE
Fixes error message not aligning with rest of form

### DIFF
--- a/@app/client/src/pages/register.tsx
+++ b/@app/client/src/pages/register.tsx
@@ -366,7 +366,7 @@ function RegistrationForm({
         )}
       </Form.Item>
       {error ? (
-        <Form.Item>
+        <Form.Item label="Error">
           <Alert
             type="error"
             message={`Registration failed`}


### PR DESCRIPTION
Hi, just was taking a look into converting the react register form to vuetify and this misaligned error bugged me.

Before:
![image](https://user-images.githubusercontent.com/8218910/72638568-f9941b00-3963-11ea-9f90-efa2ad8a1303.png)

After:
![image](https://user-images.githubusercontent.com/8218910/72638587-0749a080-3964-11ea-9d9e-9432c034a3e0.png)
