### PR TITLE
Change word "login" to "Sign in"

### DIFF
--- a/@app/client/src/pages/index.tsx
+++ b/@app/client/src/pages/index.tsx
@@ -135,7 +135,7 @@ const Home: NextPage = () => {
 
           <Title level={4}>What now?</Title>
           <Paragraph>
-            To get started, click "Sign in" at the top right, then choose 
+            To get started, click "Sign in" at the top right, then choose
             "Create One" to create a new account.
           </Paragraph>
           <Paragraph>

--- a/@app/client/src/pages/index.tsx
+++ b/@app/client/src/pages/index.tsx
@@ -135,7 +135,7 @@ const Home: NextPage = () => {
 
           <Title level={4}>What now?</Title>
           <Paragraph>
-            To get started, click "login" at the top right, then choose "Create
+            To get started, click "Sign in" at the top right, then choose "Create
             One" to create a new account.
           </Paragraph>
           <Paragraph>

--- a/@app/client/src/pages/index.tsx
+++ b/@app/client/src/pages/index.tsx
@@ -135,8 +135,8 @@ const Home: NextPage = () => {
 
           <Title level={4}>What now?</Title>
           <Paragraph>
-            To get started, click "Sign in" at the top right, then choose "Create
-            One" to create a new account.
+            To get started, click "Sign in" at the top right, then choose 
+            "Create One" to create a new account.
           </Paragraph>
           <Paragraph>
             When you're happy, you can add database changes to{" "}


### PR DESCRIPTION
The top-right of the page says "Sign in" instead of the word "login" as suggested in the copy.

![image](https://user-images.githubusercontent.com/4559119/72916514-0c2e9b80-3d3a-11ea-92df-32ec24c72ebc.png)
