### PR TITLE
Add upload router for signed S3 upload URLs

### DIFF
--- a/@app/config/src/index.ts
+++ b/@app/config/src/index.ts
@@ -6,6 +6,8 @@ const packageJson = require("../../../package.json");
 export const fromEmail =
   '"PostGraphile Starter" <no-reply@examples.graphile.org>';
 export const awsRegion = "us-east-1";
+export const uploadBucket = "my-bucket-name-here";
+export const uploadBucketPublicUrlPrefix = null;
 export const projectName = packageJson.name;
 export const companyName = projectName; // For copyright ownership
 export const emailLegalText =

--- a/@app/server/package.json
+++ b/@app/server/package.json
@@ -22,6 +22,7 @@
     "@types/passport-github": "^1.1.5",
     "@types/pg": "^7.14.1",
     "@types/redis": "^2.8.14",
+    "@types/uuid": "^3.4.7",
     "body-parser": "^1.19.0",
     "chalk": "^3.0.0",
     "connect-pg-simple": "^6.1.0",
@@ -41,7 +42,8 @@
     "postgraphile": "^4.5.5",
     "redis": "^2.8.0",
     "source-map-support": "^0.5.13",
-    "tslib": "^1.10.0"
+    "tslib": "^1.10.0",
+    "uuid": "^3.4.0"
   },
   "devDependencies": {
     "graphql": "^14.4.2",

--- a/@app/server/src/app.ts
+++ b/@app/server/src/app.ts
@@ -78,6 +78,7 @@ export async function makeApp({
   await middleware.installLogging(app);
   // These are our assets: images/etc; served out of the /@app/server/public folder (if present)
   await middleware.installSharedStatic(app);
+  await middleware.installUploadRouter(app);
   if (isTest || isDev) {
     await middleware.installCypressServerCommand(app);
   }

--- a/@app/server/src/middleware/index.ts
+++ b/@app/server/src/middleware/index.ts
@@ -8,6 +8,7 @@ import installSSR from "./installSSR";
 import installErrorHandler from "./installErrorHandler";
 import installCypressServerCommand from "./installCypressServerCommand";
 import installHelmet from "./installHelmet";
+import installUploadRouter from "./installUploadRouter";
 
 export {
   installDatabasePools,
@@ -20,4 +21,5 @@ export {
   installErrorHandler,
   installCypressServerCommand,
   installHelmet,
+  installUploadRouter,
 };

--- a/@app/server/src/middleware/installUploadRouter.ts
+++ b/@app/server/src/middleware/installUploadRouter.ts
@@ -1,0 +1,57 @@
+import { Express, Router } from "express";
+import uuidv4 from "uuid/v4";
+import * as aws from "aws-sdk";
+import {
+  awsRegion,
+  uploadBucket,
+  uploadBucketPublicUrlPrefix,
+} from "@app/config";
+
+interface Options {
+  preserveFileName?: boolean;
+  prefix?: string;
+}
+
+function makeUploadRouter({ preserveFileName, prefix }: Options = {}) {
+  const router = Router();
+  router.get("/signedUrl", async (req, res) => {
+    const contentType = req.query.contentType
+      ? String(req.query.contentType)
+      : undefined;
+    const fileName =
+      req.query.fileName && preserveFileName
+        ? String(req.query.fileName)
+        : uuidv4();
+    const fileKey = prefix ? prefix + fileName : fileName;
+    const publicUrlPrefix =
+      uploadBucketPublicUrlPrefix ||
+      `https://${uploadBucket}.s3.amazonaws.com/`;
+    const s3 = new aws.S3({
+      region: awsRegion,
+      signatureVersion: "v4",
+    });
+    const params = {
+      Bucket: uploadBucket,
+      Key: fileKey,
+      ContentType: contentType,
+      Expires: 60, // signed URL will expire in 60 seconds
+      ACL: "public-read", // uploaded file will be publicly readable
+    };
+    try {
+      const signedUrl = await s3.getSignedUrlPromise("putObject", params);
+      return res.json({
+        signedUrl,
+        publicUrl: publicUrlPrefix + fileKey,
+      });
+    } catch (err) {
+      console.log(err);
+      return res.status(500).send("Cannot create S3 signed URL");
+    }
+  });
+  return router;
+}
+
+export default async function installUploadRouter(app: Express) {
+  const router = makeUploadRouter({ preserveFileName: true });
+  app.use("/upload", router);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2950,6 +2950,11 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
 
+"@types/uuid@^3.4.7":
+  version "3.4.7"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-3.4.7.tgz#51d42247473bc00e38cc8dfaf70d936842a36c03"
+  integrity sha512-C2j2FWgQkF1ru12SjZJyMaTPxs/f6n90+5G5qNakBxKXjTBc/YTSelHh4Pz1HUDwxFXD9WvpQhOGCDC+/Y4mIQ==
+
 "@types/valid-url@1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@types/valid-url/-/valid-url-1.0.2.tgz#60fa435ce24bfd5ba107b8d2a80796aeaf3a8f45"
@@ -7643,9 +7648,9 @@ graphql-tools@4.0.6:
     uuid "^3.1.0"
 
 graphql@*, "graphql@14.0.2 - 14.2.0 || ^14.3.1", graphql@14.x, "graphql@>=0.9 <0.14 || ^14.0.2", "graphql@>=0.9 <15", "graphql@^0.6.0 || ^0.7.0 || ^0.8.0-b || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.2", graphql@^14.4.2, graphql@^14.5.8:
-  version "14.5.8"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.5.8.tgz#504f3d3114cb9a0a3f359bbbcf38d9e5bf6a6b3c"
-  integrity sha512-MMwmi0zlVLQKLdGiMfWkgQD7dY/TUKt4L+zgJ/aR0Howebod3aNgP5JkgvAULiR2HPVZaP2VEElqtdidHweLkg==
+  version "14.6.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.6.0.tgz#57822297111e874ea12f5cd4419616930cd83e49"
+  integrity sha512-VKzfvHEKybTKjQVpTFrA5yUq2S9ihcZvfJAtsDBBCuV6wauPu1xl/f9ehgVf0FcEJJs4vz6ysb/ZMkGigQZseg==
   dependencies:
     iterall "^1.2.2"
 
@@ -15303,6 +15308,11 @@ uuid@^3.0.1, uuid@^3.1.0, uuid@^3.3.2:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.3.tgz#4568f0216e78760ee1dbf3a4d2cf53e224112866"
   integrity sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==
+
+uuid@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
+  integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
 v8-compile-cache@^2.0.3:
   version "2.1.0"


### PR DESCRIPTION
Inspired by #101, this pull request implements just a small part of the functionality available there: an API that the frontend can use to get a presigned URL for uploading a file to S3. The API is available at `/upload/signedUrl`, and returns a JSON result that looks like this:

```
{
  "signedUrl": "https://my-bucket-name-here.s3.amazonaws.com/avatar.jpg?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIIUYHKT2IF5RHTNA%2F20200210%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200210T173539Z&X-Amz-Expires=60&X-Amz-Signature=63ec203cfc1209550e19007aaa85c002cdbe3b1f5174be2770708f3da6769c81&X-Amz-SignedHeaders=host%3Bx-amz-acl&x-amz-acl=public-read",
  "publicUrl": "https://my-bucket-name-here.s3.amazonaws.com/avatar.jpg"
}
```

The API accepts two query parameters: `fileName` and `contentType`. If the `preserveFileName` option is set, `fileName` will be used for constructing the key on S3. Note that this option _will_ allow users to overwrite existing files in the S3 bucket!

Open questions:
* Would it be better to structure this as a GraphQL query rather than a RESTful API endpoint? I considered doing so, but since this query doesn't touch the database at all, I wasn't sure that it was appropriate...
* How much configuration should go in the `@app/config/src/index.ts` file, and how much should be written directly into the Javascript that generates the signed URL? This starter is an opinionated project, so I tried to walk the line between the two.
* What should we do about automated tests?