### PR TITLE
Allow running eslint from any project subdir

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,5 @@
 const { readFileSync } = require("fs");
-const schemaString = readFileSync("./data/schema.graphql", "utf8");
+const schemaString = readFileSync(`${__dirname}/data/schema.graphql`, "utf8");
 
 module.exports = {
   parser: "@typescript-eslint/parser",


### PR DESCRIPTION
Fixes #128 

If eslint is run from a subdirectory, the "./" in eslintrc.js is interpreted as relative to where it's run from, and ./data/schema.graphql cannot be found.  But __dirname is always relative to the source location, and ${__dirname}/data/schema.graphql is found.
