### PR TITLE
Snapshots now track repeated occurrences

### DIFF
--- a/@app/db/__tests__/app_private/functions/link_or_register_user.test.ts
+++ b/@app/db/__tests__/app_private/functions/link_or_register_user.test.ts
@@ -48,17 +48,17 @@ describe("when account doesn't already exist", () => {
       expect(user.is_admin).toEqual(false);
       expect(user.is_verified).toEqual(true);
       expect(snapshotSafe(user)).toMatchInlineSnapshot(`
-      Object {
-        "avatar_url": "http://example.com/avatar.jpg",
-        "created_at": "[DATE]",
-        "id": "[ID]",
-        "is_admin": false,
-        "is_verified": true,
-        "name": "GitHub User123456",
-        "updated_at": "[DATE]",
-        "username": "GHU123",
-      }
-    `);
+        Object {
+          "avatar_url": "http://example.com/avatar.jpg",
+          "created_at": "[DATE]",
+          "id": "[ID]",
+          "is_admin": false,
+          "is_verified": true,
+          "name": "GitHub User123456",
+          "updated_at": "[DATE]",
+          "username": "GHU123",
+        }
+      `);
     }));
 
   it("can login with minimal oauth details", () =>

--- a/@app/server/__tests__/mutations/__snapshots__/register.test.ts.snap
+++ b/@app/server/__tests__/mutations/__snapshots__/register.test.ts.snap
@@ -6,13 +6,13 @@ Object {
     "register": Object {
       "user": Object {
         "avatarUrl": null,
-        "createdAt": "[timestamp]",
-        "id": "[id]",
+        "createdAt": "[timestamp-1]",
+        "id": "[id-1]",
         "isAdmin": false,
         "isVerified": false,
         "name": "Test User",
-        "updatedAt": "[timestamp]",
-        "username": "testuser",
+        "updatedAt": "[timestamp-1]",
+        "username": "[username-1]",
       },
     },
   },

--- a/@app/server/__tests__/mutations/register.test.ts
+++ b/@app/server/__tests__/mutations/register.test.ts
@@ -2,7 +2,7 @@ import { asRoot } from "../../../__tests__/helpers";
 import {
   deleteTestUsers,
   runGraphQLQuery,
-  sanitise,
+  sanitize,
   setup,
   teardown,
 } from "../helpers";
@@ -56,16 +56,16 @@ test("Register", async () => {
       expect(json.data).toBeTruthy();
       expect(json.data!.register).toBeTruthy();
       expect(json.data!.register.user).toBeTruthy();
-      expect(sanitise(json.data!.register.user)).toMatchInlineSnapshot(`
+      expect(sanitize(json.data!.register.user)).toMatchInlineSnapshot(`
         Object {
           "avatarUrl": null,
-          "createdAt": "[timestamp]",
-          "id": "[id]",
+          "createdAt": "[timestamp-1]",
+          "id": "[id-1]",
           "isAdmin": false,
           "isVerified": false,
           "name": "Test User",
-          "updatedAt": "[timestamp]",
-          "username": "testuser",
+          "updatedAt": "[timestamp-1]",
+          "username": "[username-1]",
         }
       `);
       const id = json.data!.register.user.id;

--- a/@app/server/__tests__/queries/__snapshots__/currentUser.test.ts.snap
+++ b/@app/server/__tests__/queries/__snapshots__/currentUser.test.ts.snap
@@ -4,7 +4,7 @@ exports[`currentUser when logged in 1`] = `
 Object {
   "data": Object {
     "currentUser": Object {
-      "id": "[id]",
+      "id": "[id-1]",
     },
   },
 }

--- a/@app/server/src/plugins/PassportLoginPlugin.ts
+++ b/@app/server/src/plugins/PassportLoginPlugin.ts
@@ -117,7 +117,7 @@ const PassportLoginPlugin = makeExtendSchemaPlugin(build => ({
             throw e;
           } else {
             console.error(
-              "Unrecognised error in PassportLoginPlugin; replacing with sanitised version"
+              "Unrecognised error in PassportLoginPlugin; replacing with sanitized version"
             );
             console.error(e);
             const error = new Error("Registration failed");

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -87,8 +87,6 @@ if (process.argv.length > 3) {
       killOthers: ["failure"],
     }
   );
-} else if (arg) {
-  throw new Error(`Argument '${arg}' not understood`);
 } else {
   // Run once, so just run the tests
   spawnSync("jest", ["-i", ...process.argv.slice(2)], opts);


### PR DESCRIPTION
Fixes #122 

sanitize replaces variable values with placeholders. Previously these placeholders were like `[timestamp]` or `[id]` which hid if they were the same as or different from other values. Now we track the values seen during an individual test, so it's possible to determine if these variable values reference each other.