### PR TITLE
Consistently order records from database

### DIFF
--- a/@app/db/__tests__/app_public/functions/change_password.test.ts
+++ b/@app/db/__tests__/app_public/functions/change_password.test.ts
@@ -31,8 +31,8 @@ it("can change password", () =>
     // Assertions
     const { rows: secrets } = await asRoot(client, () =>
       client.query(
-        "select * from app_private.user_secrets where password_hash = crypt($1, password_hash)",
-        [newPassword]
+        "select * from app_private.user_secrets where user_id = $1 and password_hash = crypt($2, password_hash)",
+        [user.id, newPassword]
       )
     );
 

--- a/@app/db/__tests__/app_public/functions/invite_to_organization.test.ts
+++ b/@app/db/__tests__/app_public/functions/invite_to_organization.test.ts
@@ -69,7 +69,7 @@ it("Can invite user to organization", () =>
     // Assertions
     const { rows: invitations } = await asRoot(client, () =>
       client.query(
-        "select * from app_public.organization_invitations where organization_id = $1",
+        "select * from app_public.organization_invitations where organization_id = $1 order by id asc",
         [organization.id]
       )
     );

--- a/@app/db/__tests__/app_public/tables/user_emails.test.ts
+++ b/@app/db/__tests__/app_public/tables/user_emails.test.ts
@@ -127,7 +127,7 @@ it("cannot see other user's emails (verified or otherwise)", () =>
     // Block-scoped variables FTW
     {
       const { rows } = await client.query(
-        "select * from app_public.user_emails"
+        "select * from app_public.user_emails order by id asc"
       );
       const userIds = rows
         .map((row) => row.user_id)
@@ -138,7 +138,7 @@ it("cannot see other user's emails (verified or otherwise)", () =>
     // And just to check that our test is valid
     await asRoot(client, async () => {
       const { rows } = await client.query(
-        "select * from app_public.user_emails"
+        "select * from app_public.user_emails order by id asc"
       );
       const userIds = rows
         .map((row) => row.user_id)

--- a/@app/db/__tests__/helpers.ts
+++ b/@app/db/__tests__/helpers.ts
@@ -101,9 +101,10 @@ export const becomeUser = async (
 
 export const getSessions = async (client: PoolClient, userId: string) => {
   const { rows } = await asRoot(client, () =>
-    client.query(`select * from app_private.sessions where user_id = $1`, [
-      userId,
-    ])
+    client.query(
+      `select * from app_private.sessions where user_id = $1 order by uuid asc`,
+      [userId]
+    )
   );
   return rows;
 };
@@ -182,7 +183,7 @@ export const getJobs = async (
 ) => {
   const { rows } = await asRoot(client, () =>
     client.query(
-      "select * from graphile_worker.jobs where $1::text is null or task_identifier = $1::text",
+      "select * from graphile_worker.jobs where $1::text is null or task_identifier = $1::text order by id asc",
       [taskIdentifier]
     )
   );

--- a/@app/worker/src/tasks/user__audit.ts
+++ b/@app/worker/src/tasks/user__audit.ts
@@ -145,7 +145,7 @@ const task: Task = async (rawPayload, { addJob, withPgClient, job }) => {
       created_at: Date;
       updated_at: Date;
     }>(
-      "select * from app_public.user_emails where user_id = $1 and is_verified is true",
+      "select * from app_public.user_emails where user_id = $1 and is_verified is true order by id asc",
       [payload.user_id]
     )
   );


### PR DESCRIPTION
Our tests _seem_ stable, but this should increase their stability by ensuring records returned are always in a defined order. Beware: where PKs are UUIDs, order is not necessarily insertion order.