### PR TITLE
Remove the 'query: Query' field from Query

### DIFF
--- a/@app/server/src/middleware/installPostGraphile.ts
+++ b/@app/server/src/middleware/installPostGraphile.ts
@@ -18,6 +18,7 @@ import { getHttpServer, getWebsocketMiddlewares } from "../app";
 import OrdersPlugin from "../plugins/Orders";
 import PassportLoginPlugin from "../plugins/PassportLoginPlugin";
 import PrimaryKeyMutationsOnlyPlugin from "../plugins/PrimaryKeyMutationsOnlyPlugin";
+import RemoveQueryQueryPlugin from "../plugins/RemoveQueryQueryPlugin";
 import SubscriptionsPlugin from "../plugins/SubscriptionsPlugin";
 import handleErrors from "../utils/handleErrors";
 import { getAuthPgPool, getRootPgPool } from "./installDatabasePools";
@@ -153,6 +154,10 @@ export function getPostGraphileOptions({
      *   https://www.graphile.org/postgraphile/extending/
      */
     appendPlugins: [
+      // PostGraphile adds a `query: Query` field to `Query` for Relay 1
+      // compatibility. We don't need that.
+      RemoveQueryQueryPlugin,
+
       // Adds support for our `postgraphile.tags.json5` file
       TagsFilePlugin,
 

--- a/@app/server/src/plugins/RemoveQueryQueryPlugin.ts
+++ b/@app/server/src/plugins/RemoveQueryQueryPlugin.ts
@@ -1,0 +1,15 @@
+import { Plugin } from "postgraphile";
+
+const RemoveQueryQueryPlugin: Plugin = (builder) => {
+  builder.hook("GraphQLObjectType:fields", (fields, build, context) => {
+    if (context.scope.isRootQuery) {
+      const { query, ...rest } = fields;
+      // Drop the `query` field
+      return rest;
+    } else {
+      return fields;
+    }
+  });
+};
+
+export default RemoveQueryQueryPlugin;

--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -947,12 +947,6 @@ type Query {
     """The method to use when ordering `Organization`."""
     orderBy: [OrganizationsOrderBy!] = [PRIMARY_KEY_ASC]
   ): OrganizationsConnection
-
-  """
-  Exposes the root query type nested one level down. This is helpful for Relay 1
-  which can only query top level fields if they are in a particular form.
-  """
-  query: Query!
   user(id: UUID!): User
   userAuthentication(id: UUID!): UserAuthentication
   userByUsername(username: String!): User


### PR DESCRIPTION
This was for Relay 1 compatibility, we don't need it.