### PR TITLE
Tweaks

### DIFF
--- a/@app/client/src/pages/invitations/accept.tsx
+++ b/@app/client/src/pages/invitations/accept.tsx
@@ -5,6 +5,7 @@ import {
   ErrorAlert,
   Redirect,
   SharedLayout,
+  SpinPadded,
 } from "@app/components";
 import {
   InvitationDetailQuery,
@@ -14,7 +15,7 @@ import {
   useInvitationDetailQuery,
 } from "@app/graphql";
 import { getCodeFromError } from "@app/lib";
-import { Button, Col, Result, Row, Skeleton, Spin } from "antd";
+import { Button, Col, Result, Row, Skeleton } from "antd";
 import { NextPage } from "next";
 import Router, { NextRouter, useRouter } from "next/router";
 import * as qs from "querystring";
@@ -113,7 +114,7 @@ const InvitationAcceptInner: FC<InvitationAcceptInnerProps> = (props) => {
 
   let child: JSX.Element | null = null;
   if (status === Status.ACCEPTING) {
-    child = <Spin />;
+    child = <SpinPadded />;
   } else if (error || acceptError) {
     const code = getCodeFromError(error || acceptError);
     if (code === "NTFND") {

--- a/@app/client/src/pages/settings/accounts.tsx
+++ b/@app/client/src/pages/settings/accounts.tsx
@@ -3,6 +3,7 @@ import {
   ErrorAlert,
   SettingsLayout,
   SocialLoginOptions,
+  SpinPadded,
   Strong,
 } from "@app/components";
 import {
@@ -97,7 +98,7 @@ const Settings_Accounts: NextPage = () => {
 
   const linkedAccounts =
     loading || !data || !data.currentUser ? (
-      <Spin />
+      <SpinPadded />
     ) : (
       <List
         bordered

--- a/@app/components/src/SpinPadded.tsx
+++ b/@app/components/src/SpinPadded.tsx
@@ -1,0 +1,15 @@
+import Spin, { SpinProps } from "antd/lib/spin";
+import React, { FC } from "react";
+
+export const SpinPadded: FC<SpinProps> = (props) => (
+  <div
+    style={{
+      padding: "2rem",
+      display: "flex",
+      justifyContent: "center",
+      alignItems: "center",
+    }}
+  >
+    <Spin {...props} />
+  </div>
+);

--- a/@app/components/src/index.tsx
+++ b/@app/components/src/index.tsx
@@ -8,6 +8,7 @@ export * from "./Redirect";
 export * from "./SettingsLayout";
 export * from "./SharedLayout";
 export * from "./SocialLoginOptions";
+export * from "./SpinPadded";
 export * from "./StandardWidth";
 export * from "./Text";
 export * from "./Warn";

--- a/@app/components/src/organizationHooks.tsx
+++ b/@app/components/src/organizationHooks.tsx
@@ -1,10 +1,11 @@
 import { QueryResult } from "@apollo/react-common";
 import { OrganizationPage_QueryFragment } from "@app/graphql";
-import { Col, Row, Spin } from "antd";
+import { Col, Row } from "antd";
 import { useRouter } from "next/router";
 import React from "react";
 
 import { ErrorAlert, FourOhFour } from "./";
+import { SpinPadded } from "./SpinPadded";
 
 export function useOrganizationSlug() {
   const router = useRouter();
@@ -25,7 +26,7 @@ export function useOrganizationLoading(
   if (organization) {
     //child = <OrganizationPageInner organization={organization} />;
   } else if (loading) {
-    child = <Spin />;
+    child = <SpinPadded />;
   } else if (error) {
     child = <ErrorAlert error={error} />;
   } else {

--- a/@app/server/package.json
+++ b/@app/server/package.json
@@ -31,6 +31,7 @@
     "graphile-build": "^4.5.0",
     "graphile-build-pg": "^4.5.3",
     "graphile-utils": "^4.5.5",
+    "graphile-worker": "^0.5.0",
     "helmet": "^3.22.0",
     "lodash": "^4.17.15",
     "morgan": "^1.10.0",
@@ -44,6 +45,7 @@
     "tslib": "^1.11.1"
   },
   "devDependencies": {
+    "@types/node": "^12.12.31",
     "graphql": "^14.4.2",
     "mock-req": "^0.2.0"
   },

--- a/@app/server/src/app.ts
+++ b/@app/server/src/app.ts
@@ -73,6 +73,7 @@ export async function makeApp({
    * operate very rapidly to enable quick as possible server startup.
    */
   await middleware.installDatabasePools(app);
+  await middleware.installWorkerUtils(app);
   await middleware.installHelmet(app);
   await middleware.installSession(app);
   await middleware.installPassport(app);

--- a/@app/server/src/middleware/index.ts
+++ b/@app/server/src/middleware/index.ts
@@ -8,9 +8,11 @@ import installPostGraphile from "./installPostGraphile";
 import installSession from "./installSession";
 import installSharedStatic from "./installSharedStatic";
 import installSSR from "./installSSR";
+import installWorkerUtils from "./installWorkerUtils";
 
 export {
   installDatabasePools,
+  installWorkerUtils,
   installSession,
   installPassport,
   installLogging,

--- a/@app/server/src/middleware/installWorkerUtils.ts
+++ b/@app/server/src/middleware/installWorkerUtils.ts
@@ -1,0 +1,16 @@
+import { Express } from "express";
+import { makeWorkerUtils, WorkerUtils } from "graphile-worker";
+
+import { getRootPgPool } from "./installDatabasePools";
+
+export function getWorkerUtils(app: Express): WorkerUtils {
+  return app.get("workerUtils");
+}
+
+export default async (app: Express) => {
+  const workerUtils = await makeWorkerUtils({
+    pgPool: getRootPgPool(app),
+  });
+
+  app.set("workerUtils", workerUtils);
+};

--- a/@app/server/src/plugins/PassportLoginPlugin.ts
+++ b/@app/server/src/plugins/PassportLoginPlugin.ts
@@ -1,5 +1,6 @@
 import { gql, makeExtendSchemaPlugin } from "graphile-utils";
 
+import { OurGraphQLContext } from "../middleware/installPostGraphile";
 import { ERROR_MESSAGE_OVERRIDES } from "../utils/handleErrors";
 
 const PassportLoginPlugin = makeExtendSchemaPlugin((build) => ({
@@ -46,7 +47,7 @@ const PassportLoginPlugin = makeExtendSchemaPlugin((build) => ({
   `,
   resolvers: {
     Mutation: {
-      async register(_mutation, args, context, resolveInfo) {
+      async register(_mutation, args, context: OurGraphQLContext, resolveInfo) {
         const { selectGraphQLResultFromTable } = resolveInfo.graphile;
         const { username, password, email, name, avatarUrl } = args.input;
         const { rootPgPool, login, pgClient } = context;
@@ -126,7 +127,7 @@ const PassportLoginPlugin = makeExtendSchemaPlugin((build) => ({
           }
         }
       },
-      async login(_mutation, args, context, resolveInfo) {
+      async login(_mutation, args, context: OurGraphQLContext, resolveInfo) {
         const { selectGraphQLResultFromTable } = resolveInfo.graphile;
         const { username, password } = args.input;
         const { rootPgPool, login, pgClient } = context;
@@ -183,7 +184,7 @@ const PassportLoginPlugin = makeExtendSchemaPlugin((build) => ({
         }
       },
 
-      async logout(_mutation, _args, context, _resolveInfo) {
+      async logout(_mutation, _args, context: OurGraphQLContext, _resolveInfo) {
         const { pgClient, logout } = context;
         await pgClient.query("select app_public.logout();");
         await logout();

--- a/@app/server/src/plugins/SubscriptionsPlugin.ts
+++ b/@app/server/src/plugins/SubscriptionsPlugin.ts
@@ -7,6 +7,8 @@ import {
 } from "graphile-utils";
 // graphile-utils doesn't export this yet
 import { GraphQLResolveInfo } from "graphql";
+
+import { OurGraphQLContext } from "../middleware/installPostGraphile";
 type GraphileHelpers = any;
 type AugmentedGraphQLFieldResolver<
   TSource,
@@ -105,7 +107,7 @@ function recordByIdFromTable(
   return async (
     event: TgGraphQLSubscriptionPayload,
     _args: {},
-    _context: any,
+    _context: OurGraphQLContext,
     { graphile: { selectGraphQLResultFromTable } }
   ) => {
     const rows = await selectGraphQLResultFromTable(


### PR DESCRIPTION
- Gives access to WorkerUtils in express middleware (useful if you want to add webhooks, for example)
- Types our GraphQL context, so it's not an `any`
- Uses a padded and centralised spinner in various places