### PR TITLE
sponsorship: update sponsors for April 🙏

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,12 @@ sponsor our open source efforts:
 And please give some love to our featured sponsors 🤩:
 
 <table><tr>
-<td align="center"><a href="http://chads.website/"><img src="https://www.graphile.org/images/sponsors/chadf.png" width="90" height="90" alt="Chad Furman" /><br />Chad Furman</a></td>
-<td align="center"><a href="https://storyscript.io/?utm_source=postgraphile"><img src="https://www.graphile.org/images/sponsors/storyscript.png" width="90" height="90" alt="Storyscript" /><br />Storyscript</a></td>
+<td align="center"><a href="http://chads.website"><img src="https://graphile.org/images/sponsors/chadf.png" width="90" height="90" alt="Chad Furman" /><br />Chad Furman</a> *</td>
+<td align="center"><a href="https://storyscript.io/?utm_source=postgraphile"><img src="https://graphile.org/images/sponsors/storyscript.png" width="90" height="90" alt="Storyscript" /><br />Storyscript</a> *</td>
+<td align="center"><a href="https://postlight.com/?utm_source=graphile"><img src="https://graphile.org/images/sponsors/postlight.png" width="90" height="90" alt="Postlight" /><br />Postlight</a> *</td>
 </tr></table>
+
+<em>\* Sponsors the entire Graphile suite</em>
 
 <!-- SPONSORS_END -->
 

--- a/SPONSORS.md
+++ b/SPONSORS.md
@@ -1,0 +1,54 @@
+# Sponsors
+
+These individuals and companies sponsor ongoing development of projects in the
+Graphile ecosystem. Find out
+[how you can become a sponsor](https://graphile.org/sponsor/).
+
+## Featured
+
+- Chad Furman
+- Storyscript
+- Postlight
+
+## Leaders
+
+- Joe Dennis
+- domonda
+- Robert Claypool
+- James Allain
+- Stagency
+- Jack Dinker
+- 8th Light
+- Nigel Taylor
+- DocIQ
+- Principia Mentis
+- Qwick
+- Partners in School Innovation
+- OpenLaw NZ
+- Sterblue
+- HR-ON
+- Ian Stewart
+- Janakan Arulkumarasan
+
+## Supporters
+
+- Daniel Einspanjer
+- Sam Levin
+- stlbucket
+- Matt Bretl
+- Chris Watland
+- James Rascoe
+- Mark Lipscombe
+- Michel Pelletier
+- Frank
+- Mark Rapoza
+- innovation.rocks
+- cybere
+- Daniel Woelfel
+- Philipp Litzenberger
+- Bjørn Michelsen
+- CJ
+- Ben Botwin
+- Cameron Ellis
+- Mansoor Razzaq
+- Borut Jures


### PR DESCRIPTION
Here is a sponsorship update for April, which adds 💙Postlight 💙 to our featured sponsors  and includes a new `sponsors.md` file. This is the first time I've done this through a script.

✨Thank you to each and every sponsor of Graphile, your donations are helping us to keep working during the pandemic ✨