### PR TITLE
Upload avatar

### DIFF
--- a/@app/client/src/graphql/ChangeAvatar.graphql
+++ b/@app/client/src/graphql/ChangeAvatar.graphql
@@ -1,9 +1,0 @@
-mutation ChangeAvatar($id: Int!, $patch: UserPatch!) {
-  updateUser(input: { id: $id, patch: $patch }) {
-    clientMutationId
-    user {
-      id
-      avatarUrl
-    }
-  }
-}

--- a/@app/client/src/graphql/ChangeAvatar.graphql
+++ b/@app/client/src/graphql/ChangeAvatar.graphql
@@ -1,0 +1,9 @@
+mutation ChangeAvatar($id: Int!, $patch: UserPatch!) {
+  updateUser(input: { id: $id, patch: $patch }) {
+    clientMutationId
+    user {
+      id
+      avatarUrl
+    }
+  }
+}

--- a/@app/client/src/graphql/CreateUploadUrl.graphql
+++ b/@app/client/src/graphql/CreateUploadUrl.graphql
@@ -1,0 +1,5 @@
+mutation CreateUploadUrl($input: CreateUploadUrlInput!) {
+  createUploadUrl(input: $input) {
+    uploadUrl
+  }
+}

--- a/@app/client/src/graphql/UpdateUser.graphql
+++ b/@app/client/src/graphql/UpdateUser.graphql
@@ -5,6 +5,7 @@ mutation UpdateUser($id: UUID!, $patch: UserPatch!) {
       id
       name
       username
+      avatarUrl
     }
   }
 }

--- a/@app/client/src/pages/settings/index.tsx
+++ b/@app/client/src/pages/settings/index.tsx
@@ -15,7 +15,7 @@ import {
   getCodeFromError,
   tailFormItemLayout,
 } from "@app/lib";
-import { Alert, Button, Form, Input, PageHeader } from "antd";
+import { Alert, Button, Card, Form, Input, PageHeader } from "antd";
 import { useForm } from "antd/lib/form/util";
 import { ApolloError } from "apollo-client";
 import { NextPage } from "next";
@@ -109,71 +109,80 @@ function ProfileSettingsForm({
   const code = getCodeFromError(error);
   return (
     <div>
-      <PageHeader title="Edit profile" />
-      <Form
-        {...formItemLayout}
-        form={form}
-        onFinish={handleSubmit}
-        initialValues={{ name: user.name, username: user.username }}
-      >
-        <Form.Item label="Avatar">
+      <PageHeader title="Profile" />
+      <Card title="Update profile information" style={{ margin: "1rem" }}>
+        <Form
+          {...formItemLayout}
+          form={form}
+          onFinish={handleSubmit}
+          initialValues={{ name: user.name, username: user.username }}
+        >
+          <Form.Item
+            label="Name"
+            name="name"
+            rules={[
+              {
+                required: true,
+                message: "Please enter your name",
+              },
+            ]}
+          >
+            <Input />
+          </Form.Item>
+          <Form.Item
+            label="Username"
+            name="username"
+            rules={[
+              {
+                required: true,
+                message: "Please choose a username",
+              },
+            ]}
+          >
+            <Input />
+          </Form.Item>
+          {error ? (
+            <Form.Item {...tailFormItemLayout}>
+              <Alert
+                type="error"
+                message={`Updating username`}
+                description={
+                  <span>
+                    {extractError(error).message}
+                    {code ? (
+                      <span>
+                        {" "}
+                        (Error code: <code>ERR_{code}</code>)
+                      </span>
+                    ) : null}
+                  </span>
+                }
+              />
+            </Form.Item>
+          ) : success ? (
+            <Form.Item {...tailFormItemLayout}>
+              <Alert type="success" message={`Profile updated`} />
+            </Form.Item>
+          ) : null}
+          <Form.Item {...tailFormItemLayout}>
+            <Button htmlType="submit">Update Profile</Button>
+          </Form.Item>
+        </Form>
+      </Card>
+      <Card title="Update avatar" style={{ margin: "1rem" }}>
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "center",
+          }}
+        >
           <AvatarUpload
             user={user}
             setError={setError}
             setSuccess={setSuccess}
           />
-        </Form.Item>
-        <Form.Item
-          label="Name"
-          name="name"
-          rules={[
-            {
-              required: true,
-              message: "Please enter your name",
-            },
-          ]}
-        >
-          <Input />
-        </Form.Item>
-        <Form.Item
-          label="Username"
-          name="username"
-          rules={[
-            {
-              required: true,
-              message: "Please choose a username",
-            },
-          ]}
-        >
-          <Input />
-        </Form.Item>
-        {error ? (
-          <Form.Item {...tailFormItemLayout}>
-            <Alert
-              type="error"
-              message={`Updating username`}
-              description={
-                <span>
-                  {extractError(error).message}
-                  {code ? (
-                    <span>
-                      {" "}
-                      (Error code: <code>ERR_{code}</code>)
-                    </span>
-                  ) : null}
-                </span>
-              }
-            />
-          </Form.Item>
-        ) : success ? (
-          <Form.Item {...tailFormItemLayout}>
-            <Alert type="success" message={`Profile updated`} />
-          </Form.Item>
-        ) : null}
-        <Form.Item {...tailFormItemLayout}>
-          <Button htmlType="submit">Update Profile</Button>
-        </Form.Item>
-      </Form>
+        </div>
+      </Card>
     </div>
   );
 }

--- a/@app/client/src/pages/settings/index.tsx
+++ b/@app/client/src/pages/settings/index.tsx
@@ -1,4 +1,9 @@
-import { ErrorAlert, Redirect, SettingsLayout } from "@app/components";
+import {
+  AvatarUpload,
+  ErrorAlert,
+  Redirect,
+  SettingsLayout,
+} from "@app/components";
 import {
   ProfileSettingsForm_UserFragment,
   useSettingsProfileQuery,
@@ -111,6 +116,13 @@ function ProfileSettingsForm({
         onFinish={handleSubmit}
         initialValues={{ name: user.name, username: user.username }}
       >
+        <Form.Item label="Avatar">
+          <AvatarUpload
+            user={user}
+            setError={setError}
+            setSuccess={setSuccess}
+          />
+        </Form.Item>
         <Form.Item
           label="Name"
           name="name"
@@ -136,7 +148,7 @@ function ProfileSettingsForm({
           <Input />
         </Form.Item>
         {error ? (
-          <Form.Item>
+          <Form.Item {...tailFormItemLayout}>
             <Alert
               type="error"
               message={`Updating username`}
@@ -154,7 +166,7 @@ function ProfileSettingsForm({
             />
           </Form.Item>
         ) : success ? (
-          <Form.Item>
+          <Form.Item {...tailFormItemLayout}>
             <Alert type="success" message={`Profile updated`} />
           </Form.Item>
         ) : null}

--- a/@app/client/src/pages/settings/index.tsx
+++ b/@app/client/src/pages/settings/index.tsx
@@ -176,11 +176,7 @@ function ProfileSettingsForm({
             justifyContent: "center",
           }}
         >
-          <AvatarUpload
-            user={user}
-            setError={setError}
-            setSuccess={setSuccess}
-          />
+          <AvatarUpload user={user} />
         </div>
       </Card>
     </div>

--- a/@app/components/package.json
+++ b/@app/components/package.json
@@ -11,6 +11,7 @@
     "@apollo/react-common": "^3.1.4",
     "@apollo/react-hooks": "^3.1.5",
     "@app/graphql": "0.0.0",
+    "@app/lib": "0.0.0",
     "@types/axios": "^0.14.0",
     "antd": "^4.2.0",
     "apollo-client": "^2.6.8",

--- a/@app/components/package.json
+++ b/@app/components/package.json
@@ -11,8 +11,10 @@
     "@apollo/react-common": "^3.1.4",
     "@apollo/react-hooks": "^3.1.5",
     "@app/graphql": "0.0.0",
+    "@types/axios": "^0.14.0",
     "antd": "^4.2.0",
     "apollo-client": "^2.6.8",
+    "axios": "^0.19.2",
     "next": "^9.3.6",
     "react": "^16.13.1",
     "tslib": "^1.11.1"

--- a/@app/components/src/AvatarUpload.tsx
+++ b/@app/components/src/AvatarUpload.tsx
@@ -1,0 +1,190 @@
+import {
+  ProfileSettingsForm_UserFragment,
+  useChangeAvatarMutation,
+} from "@app/graphql";
+import { Icon, message, Upload } from "antd";
+import { UploadChangeParam } from "antd/lib/upload";
+import { RcCustomRequestOptions, UploadFile } from "antd/lib/upload/interface";
+import { ApolloError } from "apollo-client";
+import axios from "axios";
+import React, { useEffect, useState } from "react";
+import slugify from "slugify";
+
+export function getUid(name: string) {
+  const randomHex = () => Math.floor(Math.random() * 16777215).toString(16);
+  const fileNameSlug = slugify(name);
+  return randomHex() + "-" + fileNameSlug;
+}
+
+export function AvatarUpload({
+  user,
+  setSuccess,
+  setError,
+}: {
+  user: ProfileSettingsForm_UserFragment;
+  setSuccess: React.Dispatch<React.SetStateAction<boolean>>;
+  setError: (error: Error | ApolloError | null) => void;
+}) {
+  const [changeAvatar] = useChangeAvatarMutation();
+  const [fileList, setFileList] = useState<any>(
+    user && user.avatarUrl
+      ? [
+          {
+            uid: "-1",
+            name: "avatar",
+            type: "image",
+            size: 1,
+            url: user.avatarUrl,
+          },
+        ]
+      : null
+  );
+
+  useEffect(() => {
+    if (user) {
+      const avatar = user.avatarUrl;
+      if (avatar) {
+        setFileList([
+          {
+            uid: "-1",
+            name: "avatar",
+            type: "image",
+            size: 1,
+            url: avatar,
+          },
+        ]);
+      } else {
+        setFileList(null);
+      }
+    }
+  }, [user, user.avatarUrl]);
+
+  // const onChange = (info: UploadChangeParam) => {
+  //   console.log(info);
+  //   setFileList([...fileList]);
+  // };
+
+  const beforeUpload = (file: any) => {
+    const fileName = file.name.split(".")[0];
+    const fileType = file.name.split(".")[1];
+    file.uid = getUid(fileName) + "." + fileType;
+    const isJpgOrPng = file.type === "image/jpeg" || file.type === "image/png";
+    if (!isJpgOrPng) {
+      message.error("You can only upload JPG or PNG images!");
+      file.status = "error";
+    }
+    const isLt3M = file.size / 1024 / 1024 < 3;
+    if (!isLt3M) {
+      message.error("Image must smaller than 3MB!");
+      file.status = "error";
+    }
+    return isJpgOrPng && isLt3M;
+  };
+
+  const changeUserAvatar = async (avatarUrl: string | null) => {
+    setSuccess(false);
+    setError(null);
+    try {
+      await changeAvatar({
+        variables: {
+          id: user.id,
+          patch: {
+            avatarUrl,
+          },
+        },
+      });
+      setError(null);
+      setSuccess(true);
+    } catch (e) {
+      setError(e);
+    }
+  };
+
+  const customRequest = (option: RcCustomRequestOptions) => {
+    const { onSuccess, onError, file, onProgress } = option;
+    axios
+      .get(`${process.env.ROOT_URL}/api/s3`, {
+        params: {
+          key: file.uid,
+          operation: "put",
+        },
+      })
+      .then((response) => {
+        const preSignedUrl = response.data.url;
+        axios
+          .put(preSignedUrl, file, {
+            onUploadProgress: (e) => {
+              const progress = Math.round((e.loaded / e.total) * 100);
+              onProgress({ percent: progress }, file);
+            },
+          })
+          .then((response) => {
+            if (response.config.url) {
+              changeUserAvatar(response.config.url.split("?")[0]);
+              onSuccess(response.config, file);
+            }
+          })
+          .catch((error) => {
+            console.log(error);
+            onError(error);
+          });
+      })
+      .catch((error) => {
+        console.log(error);
+        onError(error);
+      });
+  };
+
+  const deleteUserAvatarFromBucket = async () => {
+    if (user && user.avatarUrl) {
+      const key = user.avatarUrl.substring(user.avatarUrl.lastIndexOf("/") + 1);
+      await axios
+        .get(`${process.env.ROOT_URL}/api/s3`, {
+          params: {
+            key: `${key}`,
+            operation: "delete",
+          },
+        })
+        .then(() => {
+          // this isn't confirmation that the item was deleted
+          // only confimation that there wasnt an error..
+          changeUserAvatar(null);
+          return true;
+        })
+        .catch((error) => {
+          console.log(JSON.stringify(error));
+          return false;
+        });
+    }
+    return true;
+  };
+
+  const onRemove = async () => {
+    if (await deleteUserAvatarFromBucket()) {
+      setFileList(null);
+    }
+  };
+
+  const uploadButton = (
+    <div>
+      <Icon type="plus" />
+      <div className="ant-upload-text">Avatar</div>
+    </div>
+  );
+
+  return (
+    <div>
+      <Upload
+        name="avatar"
+        listType="picture-card"
+        fileList={fileList}
+        beforeUpload={beforeUpload}
+        customRequest={customRequest}
+        onRemove={onRemove}
+        showUploadList={{ showPreviewIcon: false, showDownloadIcon: false }}
+      >
+        {fileList && fileList.length >= 0 ? null : uploadButton}
+      </Upload>
+    </div>
+  );
+}

--- a/@app/components/src/AvatarUpload.tsx
+++ b/@app/components/src/AvatarUpload.tsx
@@ -1,6 +1,6 @@
 import {
   ProfileSettingsForm_UserFragment,
-  useChangeAvatarMutation,
+  useUpdateUserMutation,
 } from "@app/graphql";
 import { Icon, message, Upload } from "antd";
 import { UploadChangeParam } from "antd/lib/upload";
@@ -25,7 +25,7 @@ export function AvatarUpload({
   setSuccess: React.Dispatch<React.SetStateAction<boolean>>;
   setError: (error: Error | ApolloError | null) => void;
 }) {
-  const [changeAvatar] = useChangeAvatarMutation();
+  const [updateUser] = useUpdateUserMutation();
   const [fileList, setFileList] = useState<any>(
     user && user.avatarUrl
       ? [
@@ -85,7 +85,7 @@ export function AvatarUpload({
     setSuccess(false);
     setError(null);
     try {
-      await changeAvatar({
+      await updateUser({
         variables: {
           id: user.id,
           patch: {

--- a/@app/components/src/SharedLayout.tsx
+++ b/@app/components/src/SharedLayout.tsx
@@ -18,6 +18,7 @@ import { useCallback } from "react";
 
 import { ErrorAlert, H3, StandardWidth, Warn } from ".";
 import { Redirect } from "./Redirect";
+import { UserAvatar } from "./UserAvatar";
 
 const { Header, Content, Footer } = Layout;
 const { Text } = Typography;
@@ -243,9 +244,7 @@ export function SharedLayout({
                   data-cy="layout-dropdown-user"
                   style={{ whiteSpace: "nowrap" }}
                 >
-                  <Avatar>
-                    {(data.currentUser.name && data.currentUser.name[0]) || "?"}
-                  </Avatar>
+                  <UserAvatar user={data.currentUser} />
                   <Warn okay={data.currentUser.isVerified}>
                     <span style={{ marginLeft: 8, marginRight: 8 }}>
                       {data.currentUser.name}

--- a/@app/components/src/UserAvatar.tsx
+++ b/@app/components/src/UserAvatar.tsx
@@ -2,7 +2,10 @@ import { Avatar } from "antd";
 import React, { FC } from "react";
 
 export const UserAvatar: FC<{
-  user: { name: string; avatarUrl: string | null | undefined };
+  user: {
+    name?: string | null;
+    avatarUrl?: string | null;
+  };
 }> = (props) => {
   const { name, avatarUrl } = props.user;
   if (avatarUrl) {

--- a/@app/components/src/UserAvatar.tsx
+++ b/@app/components/src/UserAvatar.tsx
@@ -1,0 +1,13 @@
+import { Avatar } from "antd";
+import React, { FC } from "react";
+
+export const UserAvatar: FC<{
+  user: { name: string; avatarUrl: string | null | undefined };
+}> = (props) => {
+  const { name, avatarUrl } = props.user;
+  if (avatarUrl) {
+    return <Avatar src={avatarUrl} />;
+  } else {
+    return <Avatar>{(name && name[0]) || "?"}</Avatar>;
+  }
+};

--- a/@app/components/src/index.tsx
+++ b/@app/components/src/index.tsx
@@ -1,3 +1,4 @@
+export * from "./AvatarUpload";
 export * from "./ButtonLink";
 export * from "./ErrorAlert";
 export * from "./ErrorOccurred";
@@ -11,5 +12,6 @@ export * from "./SocialLoginOptions";
 export * from "./SpinPadded";
 export * from "./StandardWidth";
 export * from "./Text";
+export * from "./UserAvatar";
 export * from "./Warn";
 export * from "./organizationHooks";

--- a/@app/config/src/index.ts
+++ b/@app/config/src/index.ts
@@ -6,6 +6,7 @@ const packageJson = require("../../../package.json");
 export const fromEmail =
   '"PostGraphile Starter" <no-reply@examples.graphile.org>';
 export const awsRegion = "us-east-1";
+export const uploadBucket = process.env.AWS_BUCKET_UPLOAD;
 export const projectName = packageJson.name.replace(/[-_]/g, " ");
 export const companyName = projectName; // For copyright ownership
 export const emailLegalText =

--- a/@app/config/src/index.ts
+++ b/@app/config/src/index.ts
@@ -5,8 +5,6 @@ const packageJson = require("../../../package.json");
 
 export const fromEmail =
   '"PostGraphile Starter" <no-reply@examples.graphile.org>';
-export const awsRegion = "us-east-1";
-export const uploadBucket = process.env.AWS_BUCKET_UPLOAD;
 export const projectName = packageJson.name.replace(/[-_]/g, " ");
 export const companyName = projectName; // For copyright ownership
 export const emailLegalText =

--- a/@app/server/package.json
+++ b/@app/server/package.json
@@ -6,6 +6,7 @@
     "build": "tsc -b",
     "start": "node -r @app/config/env dist/index.js",
     "dev": "nodemon --signal SIGINT --watch 'dist/**/*.js' -x 'node --inspect=9678 -r @app/config/env -r source-map-support/register' dist/index.js",
+    "schema:export": "node -r @app/config/env node_modules/.bin/ts-node -O '{\"rootDir\":null}' scripts/schema-export.ts",
     "test": "NODE_ENV=test node -r @app/config/env ./node_modules/.bin/jest"
   },
   "dependencies": {
@@ -52,7 +53,8 @@
     "@types/node": "^13.13.4",
     "graphql": "^14.4.2",
     "jest": "^25.5.4",
-    "mock-req": "^0.2.0"
+    "mock-req": "^0.2.0",
+    "ts-node": "^8.10.1"
   },
   "optionalDependencies": {
     "bufferutil": "^4.0.1",

--- a/@app/server/package.json
+++ b/@app/server/package.json
@@ -23,6 +23,8 @@
     "@types/passport-github2": "^1.2.4",
     "@types/pg": "^7.14.1",
     "@types/redis": "^2.8.18",
+    "@types/uuid": "^7.0.3",
+    "aws-sdk": "^2.668.0",
     "body-parser": "^1.19.0",
     "chalk": "^4.0.0",
     "connect-pg-simple": "^6.1.0",
@@ -43,7 +45,8 @@
     "postgraphile": "^4.7.0",
     "redis": "^3.0.2",
     "source-map-support": "^0.5.13",
-    "tslib": "^1.11.1"
+    "tslib": "^1.11.1",
+    "uuid": "^8.0.0"
   },
   "devDependencies": {
     "@types/node": "^13.13.4",

--- a/@app/server/scripts/schema-export.ts
+++ b/@app/server/scripts/schema-export.ts
@@ -1,0 +1,31 @@
+import { writeFileSync } from "fs";
+import { printSchema } from "graphql";
+import { Pool } from "pg";
+import { createPostGraphileSchema } from "postgraphile";
+
+import { getPostGraphileOptions } from "../src/middleware/installPostGraphile";
+
+async function main() {
+  const rootPgPool = new Pool({
+    connectionString: process.env.DATABASE_URL!,
+  });
+  try {
+    const schema = await createPostGraphileSchema(
+      process.env.AUTH_DATABASE_URL!,
+      "app_public",
+      getPostGraphileOptions({ rootPgPool })
+    );
+    writeFileSync(
+      `${__dirname}/../../../data/schema.graphql`,
+      printSchema(schema)
+    );
+    console.log("GraphQL schema exported");
+  } finally {
+    rootPgPool.end();
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/@app/server/src/middleware/installPostGraphile.ts
+++ b/@app/server/src/middleware/installPostGraphile.ts
@@ -15,6 +15,7 @@ import {
 import { makePgSmartTagsFromFilePlugin } from "postgraphile/plugins";
 
 import { getHttpServer, getWebsocketMiddlewares } from "../app";
+import CreateUploadUrlPlugin from "../plugins/CreateUploadUrlPlugin";
 import OrdersPlugin from "../plugins/Orders";
 import PassportLoginPlugin from "../plugins/PassportLoginPlugin";
 import PrimaryKeyMutationsOnlyPlugin from "../plugins/PrimaryKeyMutationsOnlyPlugin";
@@ -183,6 +184,9 @@ export function getPostGraphileOptions({
 
       // Adds custom orders to our GraphQL schema
       OrdersPlugin,
+
+      // Allows API clients to fetch a pre-signed URL for uploading files
+      CreateUploadUrlPlugin,
     ],
 
     /*

--- a/@app/server/src/plugins/CreateUploadUrlPlugin.ts
+++ b/@app/server/src/plugins/CreateUploadUrlPlugin.ts
@@ -1,0 +1,197 @@
+import { awsRegion, uploadBucket } from "@app/config";
+import * as aws from "aws-sdk";
+import { gql, makeExtendSchemaPlugin } from "graphile-utils";
+import { Pool } from "pg";
+import { v4 as uuidv4 } from "uuid";
+
+import { OurGraphQLContext } from "../middleware/installPostGraphile";
+
+enum AllowedUploadContentType {
+  IMAGE_APNG = "image/apng",
+  IMAGE_BMP = "image/bmp",
+  IMAGE_GIF = "image/gif",
+  IMAGE_JPEG = "image/jpeg",
+  IMAGE_PNG = "image/png",
+  IMAGE_SVG_XML = "image/svg+xml",
+  IMAGE_TIFF = "image/tiff",
+  IMAGE_WEBP = "image/webp",
+}
+
+interface CreateUploadUrlInput {
+  clientMutationId?: string;
+  contentType: AllowedUploadContentType;
+}
+
+/** The minimal set of information that this plugin needs to know about users. */
+interface User {
+  id: string;
+  isVerified: boolean;
+}
+
+async function getCurrentUser(pool: Pool): Promise<User | null> {
+  await pool.query("SAVEPOINT");
+  try {
+    const {
+      rows: [row],
+    } = await pool.query(
+      "select id, is_verified from app_public.users where id = app_public.current_user_id()"
+    );
+    if (!row) {
+      return null;
+    }
+    return {
+      id: row.id,
+      isVerified: row.is_verified,
+    };
+  } catch (err) {
+    await pool.query("ROLLBACK TO SAVEPOINT");
+    throw err;
+  } finally {
+    await pool.query("RELEASE SAVEPOINT");
+  }
+}
+
+const CreateUploadUrlPlugin = makeExtendSchemaPlugin(() => ({
+  typeDefs: gql`
+    """
+    The set of content types that we allow users to upload.
+    """
+    enum AllowedUploadContentType {
+      """
+      image/apng
+      """
+      IMAGE_APNG
+      """
+      image/bmp
+      """
+      IMAGE_BMP
+      """
+      image/gif
+      """
+      IMAGE_GIF
+      """
+      image/jpeg
+      """
+      IMAGE_JPEG
+      """
+      image/png
+      """
+      IMAGE_PNG
+      """
+      image/svg+xml
+      """
+      IMAGE_SVG_XML
+      """
+      image/tiff
+      """
+      IMAGE_TIFF
+      """
+      image/webp
+      """
+      IMAGE_WEBP
+    }
+
+    """
+    All input for the \`createUploadUrl\` mutation.
+    """
+    input CreateUploadUrlInput @scope(isMutationInput: true) {
+      """
+      An arbitrary string value with no semantic meaning. Will be included in the
+      payload verbatim. May be used to track mutations by the client.
+      """
+      clientMutationId: String
+
+      """
+      You must provide the content type (or MIME type) of the content you intend
+      to upload. For further information about content types, see
+      https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types
+      """
+      contentType: AllowedUploadContentType!
+    }
+
+    """
+    The output of our \`createUploadUrl\` mutation.
+    """
+    type CreateUploadUrlPayload @scope(isMutationPayload: true) {
+      """
+      The exact same \`clientMutationId\` that was provided in the mutation input,
+      unchanged and unused. May be used by a client to track mutations.
+      """
+      clientMutationId: String
+
+      """
+      Upload content to this signed URL.
+      """
+      uploadUrl: String!
+    }
+
+    extend type Mutation {
+      """
+      Get a signed URL for uploading files. It will expire in 5 minutes.
+      """
+      createUploadUrl(
+        """
+        The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+        """
+        input: CreateUploadUrlInput!
+      ): CreateUploadUrlPayload
+    }
+  `,
+  resolvers: {
+    Mutation: {
+      async createUploadUrl(
+        _query,
+        args: { input: CreateUploadUrlInput },
+        context: OurGraphQLContext,
+        _resolveInfo
+      ) {
+        if (!uploadBucket) {
+          const err = new Error(
+            "Server misconfigured: missing `AWS_BUCKET_UPLOAD` envvar"
+          );
+          // @ts-ignore
+          err.code = "MSCFG";
+          throw err;
+        }
+
+        const user = await getCurrentUser(context.rootPgPool);
+
+        if (!user) {
+          const err = new Error("Login required");
+          // @ts-ignore
+          err.code = "LOGIN";
+          throw err;
+        }
+
+        if (!user.isVerified) {
+          const err = new Error("Only verified users may upload files");
+          // @ts-ignore
+          err.code = "DNIED";
+          throw err;
+        }
+
+        const { input } = args;
+        const contentType: string = AllowedUploadContentType[input.contentType];
+        const s3 = new aws.S3({
+          region: awsRegion,
+          signatureVersion: "v4",
+        });
+        const params = {
+          Bucket: uploadBucket,
+          ContentType: contentType,
+          // randomly generated filename, nested under username directory
+          Key: `${user.id}/${uuidv4()}`,
+          Expires: 300, // signed URL will expire in 5 minutes
+          ACL: "public-read", // uploaded file will be publicly readable
+        };
+        const signedUrl = await s3.getSignedUrlPromise("putObject", params);
+        return {
+          clientMutationId: input.clientMutationId,
+          uploadUrl: signedUrl,
+        };
+      },
+    },
+  },
+}));
+
+export default CreateUploadUrlPlugin;

--- a/@app/server/src/utils/handleErrors.ts
+++ b/@app/server/src/utils/handleErrors.ts
@@ -58,6 +58,10 @@ export const ERROR_MESSAGE_OVERRIDES: { [code: string]: typeof pluck } = {
     fields: conflictFieldsFromError(err),
     code: "NUNIQ",
   }),
+  MSCFG: (err) => ({
+    ...pluck(err),
+    message: err.message,
+  }),
 };
 
 function conflictFieldsFromError(err: any) {

--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -23,33 +23,6 @@ type AcceptInvitationToOrganizationPayload {
   query: Query
 }
 
-"""The set of content types that we allow users to upload."""
-enum AllowedUploadContentType {
-  """image/apng"""
-  IMAGE_APNG
-
-  """image/bmp"""
-  IMAGE_BMP
-
-  """image/gif"""
-  IMAGE_GIF
-
-  """image/jpeg"""
-  IMAGE_JPEG
-
-  """image/png"""
-  IMAGE_PNG
-
-  """image/svg+xml"""
-  IMAGE_SVG_XML
-
-  """image/tiff"""
-  IMAGE_TIFF
-
-  """image/webp"""
-  IMAGE_WEBP
-}
-
 """All input for the `changePassword` mutation."""
 input ChangePasswordInput {
   """
@@ -146,7 +119,7 @@ input CreateUploadUrlInput {
   to upload. For further information about content types, see
   https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types
   """
-  contentType: AllowedUploadContentType!
+  contentType: String!
 }
 
 """The output of our `createUploadUrl` mutation."""
@@ -655,37 +628,6 @@ type Organization {
   name: String!
 
   """
-  Reads and enables pagination through a set of `OrganizationInvitation`.
-  """
-  organizationInvitations(
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """
-    A condition to be used in determining which values should be returned by the collection.
-    """
-    condition: OrganizationInvitationCondition
-
-    """Only read the first `n` values of the set."""
-    first: Int
-
-    """Only read the last `n` values of the set."""
-    last: Int
-
-    """
-    Skip the first `n` values from our `after` cursor, an alternative to cursor
-    based pagination. May not be used with `last`.
-    """
-    offset: Int
-
-    """The method to use when ordering `OrganizationInvitation`."""
-    orderBy: [OrganizationInvitationsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): OrganizationInvitationsConnection!
-
-  """
   Reads and enables pagination through a set of `OrganizationMembership`.
   """
   organizationMemberships(
@@ -728,80 +670,6 @@ input OrganizationCondition {
 
   """Checks for equality with the object’s `slug` field."""
   slug: String
-}
-
-type OrganizationInvitation {
-  code: String
-  email: String
-  id: UUID!
-
-  """
-  Reads a single `Organization` that is related to this `OrganizationInvitation`.
-  """
-  organization: Organization
-  organizationId: UUID!
-
-  """
-  Reads a single `User` that is related to this `OrganizationInvitation`.
-  """
-  user: User
-  userId: UUID
-}
-
-"""
-A condition to be used against `OrganizationInvitation` object types. All fields
-are tested for equality and combined with a logical ‘and.’
-"""
-input OrganizationInvitationCondition {
-  """Checks for equality with the object’s `id` field."""
-  id: UUID
-
-  """Checks for equality with the object’s `organizationId` field."""
-  organizationId: UUID
-
-  """Checks for equality with the object’s `userId` field."""
-  userId: UUID
-}
-
-"""A connection to a list of `OrganizationInvitation` values."""
-type OrganizationInvitationsConnection {
-  """
-  A list of edges which contains the `OrganizationInvitation` and cursor to aid in pagination.
-  """
-  edges: [OrganizationInvitationsEdge!]!
-
-  """A list of `OrganizationInvitation` objects."""
-  nodes: [OrganizationInvitation!]!
-
-  """Information to aid in pagination."""
-  pageInfo: PageInfo!
-
-  """
-  The count of *all* `OrganizationInvitation` you could get from the connection.
-  """
-  totalCount: Int!
-}
-
-"""A `OrganizationInvitation` edge in the connection."""
-type OrganizationInvitationsEdge {
-  """A cursor for use in pagination."""
-  cursor: Cursor
-
-  """The `OrganizationInvitation` at the end of the edge."""
-  node: OrganizationInvitation!
-}
-
-"""Methods to use when ordering `OrganizationInvitation`."""
-enum OrganizationInvitationsOrderBy {
-  ID_ASC
-  ID_DESC
-  NATURAL
-  ORGANIZATION_ID_ASC
-  ORGANIZATION_ID_DESC
-  PRIMARY_KEY_ASC
-  PRIMARY_KEY_DESC
-  USER_ID_ASC
-  USER_ID_DESC
 }
 
 type OrganizationMembership {
@@ -953,38 +821,6 @@ type Query {
   retrieves the `Organization` that you were invited to.
   """
   organizationForInvitation(code: String, invitationId: UUID!): Organization
-  organizationInvitation(id: UUID!): OrganizationInvitation
-
-  """
-  Reads and enables pagination through a set of `OrganizationInvitation`.
-  """
-  organizationInvitations(
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """
-    A condition to be used in determining which values should be returned by the collection.
-    """
-    condition: OrganizationInvitationCondition
-
-    """Only read the first `n` values of the set."""
-    first: Int
-
-    """Only read the last `n` values of the set."""
-    last: Int
-
-    """
-    Skip the first `n` values from our `after` cursor, an alternative to cursor
-    based pagination. May not be used with `last`.
-    """
-    offset: Int
-
-    """The method to use when ordering `OrganizationInvitation`."""
-    orderBy: [OrganizationInvitationsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): OrganizationInvitationsConnection
   organizationMembership(id: UUID!): OrganizationMembership
 
   """Reads and enables pagination through a set of `Organization`."""
@@ -1300,37 +1136,6 @@ type User {
 
   """Public-facing name (or pseudonym) of the user."""
   name: String
-
-  """
-  Reads and enables pagination through a set of `OrganizationInvitation`.
-  """
-  organizationInvitations(
-    """Read all values in the set after (below) this cursor."""
-    after: Cursor
-
-    """Read all values in the set before (above) this cursor."""
-    before: Cursor
-
-    """
-    A condition to be used in determining which values should be returned by the collection.
-    """
-    condition: OrganizationInvitationCondition
-
-    """Only read the first `n` values of the set."""
-    first: Int
-
-    """Only read the last `n` values of the set."""
-    last: Int
-
-    """
-    Skip the first `n` values from our `after` cursor, an alternative to cursor
-    based pagination. May not be used with `last`.
-    """
-    offset: Int
-
-    """The method to use when ordering `OrganizationInvitation`."""
-    orderBy: [OrganizationInvitationsOrderBy!] = [PRIMARY_KEY_ASC]
-  ): OrganizationInvitationsConnection!
 
   """
   Reads and enables pagination through a set of `OrganizationMembership`.

--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -23,6 +23,33 @@ type AcceptInvitationToOrganizationPayload {
   query: Query
 }
 
+"""The set of content types that we allow users to upload."""
+enum AllowedUploadContentType {
+  """image/apng"""
+  IMAGE_APNG
+
+  """image/bmp"""
+  IMAGE_BMP
+
+  """image/gif"""
+  IMAGE_GIF
+
+  """image/jpeg"""
+  IMAGE_JPEG
+
+  """image/png"""
+  IMAGE_PNG
+
+  """image/svg+xml"""
+  IMAGE_SVG_XML
+
+  """image/tiff"""
+  IMAGE_TIFF
+
+  """image/webp"""
+  IMAGE_WEBP
+}
+
 """All input for the `changePassword` mutation."""
 input ChangePasswordInput {
   """
@@ -104,6 +131,39 @@ type CreateOrganizationPayload {
   Our root query field type. Allows us to run any query from our mutation payload.
   """
   query: Query
+}
+
+"""All input for the `createUploadUrl` mutation."""
+input CreateUploadUrlInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  You must provide the content type (or MIME type) of the content you intend
+  to upload. For further information about content types, see
+  https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types
+  """
+  contentType: AllowedUploadContentType!
+}
+
+"""The output of our `createUploadUrl` mutation."""
+type CreateUploadUrlPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """Upload content to this signed URL."""
+  uploadUrl: String!
 }
 
 """All input for the create `UserEmail` mutation."""
@@ -390,6 +450,14 @@ type Mutation {
     """
     input: CreateOrganizationInput!
   ): CreateOrganizationPayload
+
+  """Get a signed URL for uploading files. It will expire in 5 minutes."""
+  createUploadUrl(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: CreateUploadUrlInput!
+  ): CreateUploadUrlPayload
 
   """Creates a single `UserEmail`."""
   createUserEmail(

--- a/docs/error_codes.md
+++ b/docs/error_codes.md
@@ -33,6 +33,7 @@ Rewritten, the above rules state:
 - DNIED: permission denied
 - NUNIQ: not unique (from PostgreSQL 23505)
 - NTFND: not found
+- MSCFG: server misconfigured
 
 ## Registration
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -15216,6 +15216,17 @@ ts-log@2.1.4:
   resolved "https://registry.yarnpkg.com/ts-log/-/ts-log-2.1.4.tgz#063c5ad1cbab5d49d258d18015963489fb6fb59a"
   integrity sha512-P1EJSoyV+N3bR/IWFeAqXzKPZwHpnLY6j7j58mAvewHRipo+BQM2Y1f9Y9BjEQznKwgqqZm7H8iuixmssU7tYQ==
 
+ts-node@^8.10.1:
+  version "8.10.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.10.1.tgz#77da0366ff8afbe733596361d2df9a60fc9c9bd3"
+  integrity sha512-bdNz1L4ekHiJul6SHtZWs1ujEKERJnHs4HxN7rjTyyVOFf3HaJ6sLqe6aPG62XTzAB/63pKRh5jTSWL0D7bsvw==
+  dependencies:
+    arg "^4.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    source-map-support "^0.5.17"
+    yn "3.1.1"
+
 ts-node@^8.9.1:
   version "8.9.1"
   resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.9.1.tgz#2f857f46c47e91dcd28a14e052482eb14cfd65a5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2675,6 +2675,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/axios@^0.14.0":
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/@types/axios/-/axios-0.14.0.tgz#ec2300fbe7d7dddd7eb9d3abf87999964cafce46"
+  integrity sha1-7CMA++fX3d1+udOr+HmZlkyvzkY=
+  dependencies:
+    axios "*"
+
 "@types/babel__core@^7.1.7":
   version "7.1.7"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.7.tgz#1dacad8840364a57c98d0dd4855c6dd3752c6b89"
@@ -4093,6 +4100,13 @@ aws4@^1.8.0:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.9.1.tgz#7e33d8f7d449b3f673cd72deb9abdc552dbe528e"
   integrity sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==
+
+axios@*, axios@^0.19.2:
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
+  integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
+  dependencies:
+    follow-redirects "1.5.10"
 
 babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
   version "6.26.0"
@@ -5935,7 +5949,7 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@3.1.0:
+debug@3.1.0, debug@=3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
@@ -7309,6 +7323,13 @@ flush-write-stream@^1.0.0:
   dependencies:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
+
+follow-redirects@1.5.10:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
+  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
+  dependencies:
+    debug "=3.1.0"
 
 for-in@^1.0.2:
   version "1.0.2"
@@ -11967,9 +11988,9 @@ performance-now@^2.1.0:
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
 pg-connection-string@0.1.3, pg-connection-string@2.x, pg-connection-string@^2.0.0, pg-connection-string@^2.1.0:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/pg-connection-string/-/pg-connection-string-2.2.1.tgz#fd22870c4cdff66f085a8759ee68cde8e9ca0cbf"
-  integrity sha512-WnIjIJR575VyX+jRqpSt5PqbIzr3+1D793CkBbQWvpiNTGuHffZEO9+VrwAw0XSVfvxea7QiplHINGahWe9rjg==
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/pg-connection-string/-/pg-connection-string-2.2.2.tgz#fdc2fb2084e655f0b3e6e50c69330f6932df452e"
+  integrity sha512-+hel4DGuSZCjCZwglAuyi+XlodHnKmrbyTw0hVWlmGN2o4AfJDkDo5obAFzblS5M5PFBMx0uDt5Y1QjlNC+tqg==
 
 pg-int8@1.0.1:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3174,6 +3174,11 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
 
+"@types/uuid@^7.0.3":
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-7.0.3.tgz#45cd03e98e758f8581c79c535afbd4fc27ba7ac8"
+  integrity sha512-PUdqTZVrNYTNcIhLHkiaYzoOIaUi5LFg/XLerAdgvwQrUCx+oSbtoBze1AMyvYbcwzUSNC+Isl58SM4Sm/6COw==
+
 "@types/ws@^6.0.1":
   version "6.0.4"
   resolved "https://registry.yarnpkg.com/@types/ws/-/ws-6.0.4.tgz#7797707c8acce8f76d8c34b370d4645b70421ff1"
@@ -15622,6 +15627,11 @@ uuid@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"
   integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==
+
+uuid@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.0.0.tgz#bc6ccf91b5ff0ac07bbcdbf1c7c4e150db4dbb6c"
+  integrity sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==
 
 v8-compile-cache@^2.0.3:
   version "2.1.0"


### PR DESCRIPTION
This is a work in progress PR for adding avatar upload functionality, merging #101 and #108. It's no-where near ready.

- [x] Add createSignedUrl mutation 
- [x] Add upload component
- [x] Render profile page in two seconds - one for avatar, one for textual settings
- [x] Handle errors during avatar upload flow
- [ ] Document how to configure IAM, S3, etc for uploads
- [ ] Allow configuring the system to not allow avatar uploads
- [ ] Uploads should be private and expire automatically after a few hours
- [ ] The uploaded URL should be sent to the server, validated, and then the object should be moved to public S3 that doesn't expire, and referenced in the DB so that it may later be safely deleted (beware of race conditions)
- [ ] A trigger should be added such that when a new upload is performed, the old upload gets queued for deletion
- [ ] Storage needs to be added to the database to track the uploads the user has permissions to delete

Unfortunately I timed out after 4 hours merging these PRs and attempting to implement the above functionality. 