### PR TITLE
Fix bad username normalization

### DIFF
--- a/@app/db/migrations/committed/000001.sql
+++ b/@app/db/migrations/committed/000001.sql
@@ -1,5 +1,5 @@
 --! Previous: -
---! Hash: sha1:e1b27f7832f31570c34083d3a619062bc0ae4a72
+--! Hash: sha1:4a5b89d4e3a68e88e983431b964fe47a2a6ce550
 
 drop schema if exists app_public cascade;
 
@@ -961,8 +961,8 @@ begin
   if v_username is null then
     v_username = coalesce(v_name, 'user');
   end if;
-  v_username = regexp_replace(v_username, '^[^a-z]+', '', 'i');
-  v_username = regexp_replace(v_username, '[^a-z0-9]+', '_', 'i');
+  v_username = regexp_replace(v_username, '^[^a-z]+', '', 'gi');
+  v_username = regexp_replace(v_username, '[^a-z0-9]+', '_', 'gi');
   if v_username is null or length(v_username) < 3 then
     v_username = 'user';
   end if;

--- a/data/schema.sql
+++ b/data/schema.sql
@@ -438,8 +438,8 @@ begin
   if v_username is null then
     v_username = coalesce(v_name, 'user');
   end if;
-  v_username = regexp_replace(v_username, '^[^a-z]+', '', 'i');
-  v_username = regexp_replace(v_username, '[^a-z0-9]+', '_', 'i');
+  v_username = regexp_replace(v_username, '^[^a-z]+', '', 'gi');
+  v_username = regexp_replace(v_username, '[^a-z0-9]+', '_', 'gi');
   if v_username is null or length(v_username) < 3 then
     v_username = 'user';
   end if;


### PR DESCRIPTION
Without the 'g', usernames such as @ben-pr-p will be translated to `ben_pr-p` instead of `ben_pr_p`.