### PR TITLE
Converted SharedLayout->AuthRestrict to flag enum to allow for multiple forbid conditions

### DIFF
--- a/@app/components/src/SharedLayout.tsx
+++ b/@app/components/src/SharedLayout.tsx
@@ -42,9 +42,10 @@ export interface SharedLayoutChildProps {
 }
 
 export enum AuthRestrict {
-  LOGGED_IN = "LOGGED_IN",
-  LOGGED_OUT = "LOGGED_OUT",
-  NEVER = "NEVER",
+  NEVER = 0,
+  LOGGED_OUT = 1 << 0,
+  LOGGED_IN = 1 << 1,
+  NOT_ADMIN = 1 << 2,
 }
 
 export interface SharedLayoutProps {
@@ -130,7 +131,14 @@ export function SharedLayout({
       ) : (
         children
       );
-    if (data && data.currentUser && forbidWhen === AuthRestrict.LOGGED_IN) {
+    const forbidsLoggedIn = forbidWhen & AuthRestrict.LOGGED_IN;
+    const forbidsLoggedOut = forbidWhen & AuthRestrict.LOGGED_OUT;
+    const forbidsNotAdmin = forbidWhen & AuthRestrict.NOT_ADMIN;
+    if (
+      data &&
+      data.currentUser &&
+      (forbidsLoggedIn || (forbidsNotAdmin && !data.currentUser.isAdmin))
+    ) {
       return (
         <StandardWidth>
           <Redirect href={"/"} />
@@ -141,7 +149,7 @@ export function SharedLayout({
       data.currentUser === null &&
       !loading &&
       !error &&
-      forbidWhen === AuthRestrict.LOGGED_OUT
+      forbidsLoggedOut
     ) {
       return (
         <Redirect href={`/login?next=${encodeURIComponent(router.asPath)}`} />


### PR DESCRIPTION
Also added IS_ADMIN and NOT_ADMIN flags.
This is better because it allows for multiple forbid conditions, as well as easy extension.
The IS_ADMIN/NOT_ADMIN check is kinda ugly but that's how it's auto-formatted so I've kept it like that for this PR.