### PR TITLE
Fixup some documentation urls that still refer to "master" branch

### DIFF
--- a/@app/client/assets/antd-custom.less
+++ b/@app/client/assets/antd-custom.less
@@ -1,4 +1,4 @@
-// Ref: https://github.com/ant-design/ant-design/blob/main/components/style/themes/default.less
+// Ref: https://github.com/ant-design/ant-design/blob/master/components/style/themes/default.less
 
 // IMPORTANT: you cannot use LESS helpers in this file
 // Ref: https://www.npmjs.com/package/less-vars-to-js

--- a/@app/client/assets/antd-custom.less
+++ b/@app/client/assets/antd-custom.less
@@ -1,4 +1,4 @@
-// Ref: https://github.com/ant-design/ant-design/blob/master/components/style/themes/default.less
+// Ref: https://github.com/ant-design/ant-design/blob/main/components/style/themes/default.less
 
 // IMPORTANT: you cannot use LESS helpers in this file
 // Ref: https://www.npmjs.com/package/less-vars-to-js

--- a/@app/client/src/pages/index.tsx
+++ b/@app/client/src/pages/index.tsx
@@ -80,7 +80,7 @@ const Home: NextPage = () => {
 
           <Title level={4}>
             This page:{" "}
-            <a href="https://github.com/graphile/starter/blob/master/@app/client/src/pages/index.tsx">
+            <a href="https://github.com/graphile/starter/blob/main/@app/client/src/pages/index.tsx">
               <code>@app/client/src/pages/index.tsx</code>
             </a>
           </Title>
@@ -91,7 +91,7 @@ const Home: NextPage = () => {
 
           <Title level={4}>
             The server:{" "}
-            <a href="https://github.com/graphile/starter/blob/master/@app/server/src/index.ts">
+            <a href="https://github.com/graphile/starter/blob/main/@app/server/src/index.ts">
               <code>@app/server/src/index.ts</code>
             </a>
           </Title>
@@ -115,7 +115,7 @@ const Home: NextPage = () => {
             easiest way is to run <code>yarn db uncommit</code> which will undo
             this initial migration and move its content back to current.sql for
             you to modify. Please see{" "}
-            <a href="https://github.com/graphile/migrate/blob/master/README.md">
+            <a href="https://github.com/graphile/migrate/blob/main/README.md">
               the graphile-migrate documentation
             </a>
             .

--- a/@app/db/README.md
+++ b/@app/db/README.md
@@ -17,7 +17,7 @@ may prefer to switch this out for your preferred migration framework such as
 [flyway](https://flywaydb.org/) or many many many others.
 
 Should you decide to stick with Graphile Migrate, we strongly encourage you to
-[read the Graphile Migrate README](https://github.com/graphile/migrate/blob/master/README.md)
+[read the Graphile Migrate README](https://github.com/graphile/migrate/blob/main/README.md)
 before attempting to write your own migrations. Graphile Migrate works in quite
 a different way to many other migration frameworks, and relys on your discipline
 and SQL knowledge to work well.

--- a/@app/db/migrations/README.md
+++ b/@app/db/migrations/README.md
@@ -4,7 +4,7 @@ This folder contains the database migrations. We're using the `graphile-migrate`
 project to produce these; we highly recommend you read the README before
 implementing your own migrations:
 
-https://github.com/graphile/migrate/blob/master/README.md
+https://github.com/graphile/migrate/blob/main/README.md
 
 The main file you'll be working with is `current.sql`.
 


### PR DESCRIPTION
some links were broken because they referred to "master"