### PR TITLE
Don't compile ROOT_URL into bundle

### DIFF
--- a/@app/client/src/next.config.js
+++ b/@app/client/src/next.config.js
@@ -2,8 +2,7 @@ require("@app/config");
 const compose = require("lodash/flowRight");
 const AntDDayjsWebpackPlugin = require("antd-dayjs-webpack-plugin");
 
-const { ROOT_URL, T_AND_C_URL } = process.env;
-if (!ROOT_URL) {
+if (!process.env.ROOT_URL) {
   if (process.argv[1].endsWith("/depcheck")) {
     /* NOOP */
   } else {
@@ -72,10 +71,16 @@ if (!ROOT_URL) {
           plugins: [
             ...config.plugins,
             new webpack.DefinePlugin({
-              "process.env.ROOT_URL": JSON.stringify(
-                ROOT_URL || "http://localhost:5678"
-              ),
-              "process.env.T_AND_C_URL": JSON.stringify(T_AND_C_URL || null),
+              /*
+               * IMPORTANT: we don't want to hard-code these values, otherwise
+               * we cannot promote a bundle to another environment. Further,
+               * they need to be valid both within the browser _AND_ on the
+               * server side when performing SSR.
+               */
+              "process.env.ROOT_URL":
+                "(typeof window !== 'undefined' ? window.__GRAPHILE_APP__.ROOT_URL : process.env.ROOT_URL)",
+              "process.env.T_AND_C_URL":
+                "(typeof window !== 'undefined' ? window.__GRAPHILE_APP__.T_AND_C_URL : process.env.ROOT_URL)",
             }),
             new webpack.IgnorePlugin(
               // These modules are server-side only; we don't want webpack

--- a/@app/client/src/pages/_app.tsx
+++ b/@app/client/src/pages/_app.tsx
@@ -11,11 +11,30 @@ import Router from "next/router";
 import NProgress from "nprogress";
 import * as React from "react";
 
+declare global {
+  interface Window {
+    __GRAPHILE_APP__: {
+      ROOT_URL?: string;
+      T_AND_C_URL?: string;
+    };
+  }
+}
+
 NProgress.configure({
   showSpinner: false,
 });
 
 if (typeof window !== "undefined") {
+  const nextDataEl = document.getElementById("__NEXT_DATA__");
+  if (!nextDataEl || !nextDataEl.textContent) {
+    throw new Error("Cannot read from __NEXT_DATA__ element");
+  }
+  const data = JSON.parse(nextDataEl.textContent);
+  window.__GRAPHILE_APP__ = {
+    ROOT_URL: data.query.ROOT_URL,
+    T_AND_C_URL: data.query.T_AND_C_URL,
+  };
+
   Router.events.on("routeChangeStart", () => {
     NProgress.start();
   });
@@ -30,7 +49,7 @@ if (typeof window !== "undefined") {
     } else {
       notification.open({
         message: "Page load failed",
-        description: `This is very embarassing! Please reload the page. Further error details: ${
+        description: `This is very embarrassing! Please reload the page. Further error details: ${
           typeof err === "string" ? err : err.message
         }`,
         duration: 0,

--- a/@app/server/src/middleware/installSSR.ts
+++ b/@app/server/src/middleware/installSSR.ts
@@ -36,6 +36,9 @@ export default async function installSSR(app: Express) {
       query: {
         ...parsedUrl.query,
         CSRF_TOKEN: req.csrfToken(),
+        // See 'next.config.js':
+        ROOT_URL: process.env.ROOT_URL || "http://localhost:5678",
+        T_AND_C_URL: process.env.T_AND_C_URL,
       },
     });
   });


### PR DESCRIPTION
With this change, I hope you'll be able to push your compiled staging assets up to production without needing any changes to the code, just envvar changes.

Note: staging should have `NODE_ENV=production`, since that gets compiled into `React` and other packages.

Yes I chose not to use `publicRuntimeConfig` because this way `process.env.*` can be used in non-React contexts.