### PR TITLE
Allow setting cookies from other origins

### DIFF
--- a/@app/server/src/middleware/installSession.ts
+++ b/@app/server/src/middleware/installSession.ts
@@ -75,7 +75,15 @@ export default (app: Express) => {
    * different authentication method such as bearer tokens.
    */
   const wrappedSessionMiddleware: RequestHandler = (req, res, next) => {
-    if (req.isSameOrigin) {
+    const origins = [];
+    if (process.env.SESSION_ALLOWED_ORIGINS) {
+      origins.push(
+        ...(process.env.SESSION_ALLOWED_ORIGINS?.replace(/s\s/g, "").split(
+          ","
+        ) || [])
+      );
+    }
+    if (req.isSameOrigin || origins.includes(req.get("Origin") || "")) {
       sessionMiddleware(req, res, next);
     } else {
       next();


### PR DESCRIPTION
This allows cookies to be sent from an origin other than the primary origin. This can be useful if you want to have multiple sites hosted from different sub-domains but using the same API. Additionally, in development mode, this allows you to use a separate server (such as Ionic dev server) to go against the same API.

There shouldn't be any security concerns as this by default uses same origin. It only allows changes if you specifically want to whitelist a particular domain to allow cookies from there.