### PR TITLE
add a toggle-admin script to facilitate making a user an admin

### DIFF
--- a/@app/db/scripts/toggle-admin.js
+++ b/@app/db/scripts/toggle-admin.js
@@ -1,0 +1,28 @@
+const pg = require("pg");
+
+async function main() {
+  const pgPool = new pg.Pool({
+    host: process.env.DATABASE_HOST,
+    user: process.env.DATABASE_OWNER,
+    password: process.env.DATABASE_OWNER_PASSWORD,
+    database: process.env.DATABASE_NAME,
+  });
+  try {
+    await pgPool.query(
+      `update app_public.users set is_admin = $2 where username = $1;`,
+      [process.argv[2], process.argv[3]]
+    );
+    const res = await pgPool.query(
+      `select username, is_admin from app_public.users where username = $1;`,
+      [process.argv[2]]
+    );
+    console.log(res.rows);
+  } finally {
+    await pgPool.end();
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/README.md
+++ b/README.md
@@ -277,6 +277,15 @@ To shut everything down:
 | ---------- | :-: | ------------------------------ |
 | Ctrl-c     | or  | `export UID; yarn docker down` |
 
+### Custom commands
+
+To grant admin rights to a user call toogle-admin with 1, you can also remove
+admin rights sending 0 as the last argument:
+
+```
+yarn db toggle-admin <username> <[0-1]>
+```
+
 ## Making it yours
 
 1. Download and extract a zip of


### PR DESCRIPTION
This is just a simple script to facilitate toggling the is_admin field on any user based on his/her username.
