### PR TITLE
fix: upgrade graphile-worker

### DIFF
--- a/@app/db/package.json
+++ b/@app/db/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@types/pg": "^7.14.4",
-    "graphile-worker": "^0.8.0",
+    "graphile-worker": "^0.8.1",
     "jest": "^25.5.4",
     "lodash": "^4.17.15",
     "pg": "^8.0.3"

--- a/@app/server/package.json
+++ b/@app/server/package.json
@@ -36,7 +36,7 @@
     "graphile-build": "^4.9.0",
     "graphile-build-pg": "^4.9.0",
     "graphile-utils": "^4.9.0",
-    "graphile-worker": "^0.8.0",
+    "graphile-worker": "^0.8.1",
     "helmet": "^3.22.0",
     "lodash": "^4.17.15",
     "morgan": "^1.10.0",

--- a/@app/worker/package.json
+++ b/@app/worker/package.json
@@ -18,7 +18,7 @@
     "@types/nodemailer": "^6.4.0",
     "aws-sdk": "^2.668.0",
     "chalk": "^4.0.0",
-    "graphile-worker": "^0.8.0",
+    "graphile-worker": "^0.8.1",
     "html-to-text": "^5.0.0",
     "lodash": "^4.17.15",
     "mjml": "^4.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7909,10 +7909,10 @@ graphile-utils@^4.9.0:
     graphql ">=0.9 <0.14 || ^14.0.2"
     tslib "^2.0.1"
 
-graphile-worker@^0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/graphile-worker/-/graphile-worker-0.8.0.tgz#db33b59a4d8e6d3aa8679fe6da172f334b8986a7"
-  integrity sha512-x/TdRtgU5MDmGSSQgcMKGWWVEa4dHQncerfFvXO/QQoZxJKCwu2qivHvb8D9jLtoBUnuwktlsDLCMOMtZflqJw==
+graphile-worker@^0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/graphile-worker/-/graphile-worker-0.8.1.tgz#101bc21fec8dfb1a307a9ebd290362ac7d3a3ec2"
+  integrity sha512-N6lq7pOiKOQvdMHNO/U6V07TVtpxa5ZTsH5P1VF49a2ia7Uj6XsWn9W2mGkOZXEXw/WIHYaWYe1O4UX6Gmjp4Q==
   dependencies:
     "@types/debug" "^4.1.2"
     "@types/pg" "^7.14.3"


### PR DESCRIPTION
## Description

Upgrades Graphile Worker to fix a bug in watch mode with recursive dependencies.

## Performance impact

None.

## Security impact

None.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [-] I've added tests for the new feature, and `yarn test` passes.
- [-] I have detailed the new feature in the relevant documentation.
- [-] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [-] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
