### PR TITLE
chore(ci): upgrade cypress-io/github-action@v1 to v2

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Start worker in background
         run: yarn worker start &
       - name: Cypress run
-        uses: cypress-io/github-action@v1
+        uses: cypress-io/github-action@v2
         with:
           wait-on: http://localhost:5678
           working-directory: "@app/e2e"


### PR DESCRIPTION
## Description

Upgrade cypress-io/github-action@v1 to v2 to avoid `set-env` command is disabled error that appears on github status checks.

GitHub is deprecating set-env and add-path commands, causing the cypress end-to-end status check to log the following warning when executed:

> The set-env command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/


## Performance impact

<!-- Detail any impact on performance of this PR, or put 'unknown' if not known -->

## Security impact

<!-- Detail any impact on security of this PR, or put 'unknown' if not known -->

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [ ] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
