### PR TITLE
fix: pgSettings no longers passes sessionId: false

### DIFF
--- a/@app/server/src/middleware/installPostGraphile.ts
+++ b/@app/server/src/middleware/installPostGraphile.ts
@@ -41,7 +41,7 @@ type UUID = string;
 
 const isTest = process.env.NODE_ENV === "test";
 
-function uuidOrNull(input: string | number | null): UUID | null {
+function uuidOrNull(input: string | number | null | undefined): UUID | null {
   if (!input) return null;
   const str = String(input);
   if (
@@ -218,7 +218,7 @@ export function getPostGraphileOptions({
      * whether or not you're using JWTs.
      */
     async pgSettings(req) {
-      const sessionId = req.user && uuidOrNull(req.user.session_id);
+      const sessionId = uuidOrNull(req.user?.session_id);
       if (sessionId) {
         // Update the last_active timestamp (but only do it at most once every 15 seconds to avoid too much churn).
         await rootPgPool.query(
@@ -250,7 +250,7 @@ export function getPostGraphileOptions({
     ): Promise<Partial<OurGraphQLContext>> {
       return {
         // The current session id
-        sessionId: req.user && uuidOrNull(req.user.session_id),
+        sessionId: uuidOrNull(req.user?.session_id),
 
         // Needed so passport can write to the database
         rootPgPool,


### PR DESCRIPTION
## Description

While using `starter` purely headless-ly from a mobile client, I discovered that when no session token is passed (I've modified the starter to allow JWT tokens that carry the session token, I can make a PR for that if it is wanted), the `current_user_id` function fails: 

```
(RUN) @app/mobile: [09:40:59] Object {
(RUN) @app/mobile: [09:40:59]   "data": Object {
(RUN) @app/mobile: [09:40:59]     "story": null,
(RUN) @app/mobile: [09:40:59]   },
(RUN) @app/mobile: [09:40:59]   "errors": Array [
(RUN) @app/mobile: [09:40:59]     Object {
(RUN) @app/mobile: [09:40:59]       "extensions": Object {
(RUN) @app/mobile: [09:40:59]         "exception": Object {
(RUN) @app/mobile: [09:40:59]           "code": "22P02",
(RUN) @app/mobile: [09:40:59]           "severity": "ERROR",
(RUN) @app/mobile: [09:40:59]           "where": "SQL function \"current_user_id\" statement 1
(RUN) @app/mobile: [09:40:59] SQL function \"stories_liked_by_current_user\" during startup",
(RUN) @app/mobile: [09:40:59]         },
(RUN) @app/mobile: [09:40:59]       },
(RUN) @app/mobile: [09:40:59]       "locations": Array [
(RUN) @app/mobile: [09:40:59]         Object {
(RUN) @app/mobile: [09:40:59]           "column": 3,
(RUN) @app/mobile: [09:40:59]           "line": 2,
(RUN) @app/mobile: [09:40:59]         },
(RUN) @app/mobile: [09:40:59]       ],
(RUN) @app/mobile: [09:40:59]       "message": "invalid input syntax for type uuid: \"false\"",
(RUN) @app/mobile: [09:40:59]       "path": Array [
(RUN) @app/mobile: [09:40:59]         "story",
(RUN) @app/mobile: [09:40:59]       ],
(RUN) @app/mobile: [09:40:59]     },
(RUN) @app/mobile: [09:40:59]   ],
(RUN) @app/mobile: [09:40:59] }
```

This is because `req.user && uuidOrNull(req.user.session_id)` will pass `false` as the sessionId and not null. This change makes the uuidOrNull function take `undefined`, and then uses optional chaining on `req.user` instead of doing `req.user &&`. This means that if there is no user on the request, `uuidOrNull` is passed undefined, and then returns `null` for the session ID. This stops the error shown above from occurring.

## Performance impact

None.

## Security impact

Unknown, likely none.

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.

I'm not sure if any of these are applicable as it is a simple bug fix.

- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
