### PR TITLE
feat(handleErrors): better error for foreign key violations

### DIFF
--- a/@app/server/src/utils/handleErrors.ts
+++ b/@app/server/src/utils/handleErrors.ts
@@ -60,7 +60,7 @@ export const ERROR_MESSAGE_OVERRIDES: { [code: string]: typeof pluck } = {
   }),
   "23503": (err) => ({
     ...pluck(err),
-    message: "Invalid foreign key",
+    message: "Invalid reference",
     fields: conflictFieldsFromError(err),
     code: "BADFK",
   }),

--- a/@app/server/src/utils/handleErrors.ts
+++ b/@app/server/src/utils/handleErrors.ts
@@ -65,13 +65,18 @@ function conflictFieldsFromError(err: any) {
   // TODO: extract a list of constraints from the DB
   if (constraint && table) {
     const PREFIX = `${table}_`;
-    const SUFFIX = `_key`;
-    if (constraint.startsWith(PREFIX) && constraint.endsWith(SUFFIX)) {
-      const maybeColumnNames = constraint.substr(
-        PREFIX.length,
-        constraint.length - PREFIX.length - SUFFIX.length
+    const SUFFIX_LIST = [`_key`, `_fkey`];
+    if (constraint.startsWith(PREFIX)) {
+      const matchingSuffix = SUFFIX_LIST.find((SUFFIX) =>
+        constraint.endsWith(SUFFIX)
       );
-      return [camelCase(maybeColumnNames)];
+      if (matchingSuffix) {
+        const maybeColumnNames = constraint.substr(
+          PREFIX.length,
+          constraint.length - PREFIX.length - matchingSuffix.length
+        );
+        return [camelCase(maybeColumnNames)];
+      }
     }
   }
   return undefined;

--- a/@app/server/src/utils/handleErrors.ts
+++ b/@app/server/src/utils/handleErrors.ts
@@ -58,6 +58,12 @@ export const ERROR_MESSAGE_OVERRIDES: { [code: string]: typeof pluck } = {
     fields: conflictFieldsFromError(err),
     code: "NUNIQ",
   }),
+  "23503": (err) => ({
+    ...pluck(err),
+    message: "Invalid foreign key",
+    fields: conflictFieldsFromError(err),
+    code: "BADFK",
+  }),
 };
 
 function conflictFieldsFromError(err: any) {

--- a/docs/error_codes.md
+++ b/docs/error_codes.md
@@ -33,6 +33,7 @@ Rewritten, the above rules state:
 - DNIED: permission denied
 - NUNIQ: not unique (from PostgreSQL 23505)
 - NTFND: not found
+- BADFK: foreign key violation (from PostgreSQL 23503)
 
 ## Registration
 


### PR DESCRIPTION
After this change we can determine errors for foreign key violations on the frontend.

```ts
const code = getCodeFromError(e);
const exception = getExceptionFromError(e);
const fields: any = exception && exception["fields"];
// This PR creates BADFK error code, and fixes `fields` to work with fkeys
if (code === "BADFK" && fields && fields[0] === "genre") {
  helpers.setFieldError(
    "genre",
    "That genre does not exist in our database. Please pick an existing one, or don't provide a genre at all."
  );
} else {
  helpers.setStatus({
    error: true,
    message: e?.message || "Unknown error",
  });
}
```

I don't see anywhere in the current codebase this would be used or that this would affect, although I may have missed something. It's more a case of expected behaviour than specifically a fix for this project front-end.