### PR TITLE
Fix username validation

### DIFF
--- a/@app/db/migrations/committed/000001.sql
+++ b/@app/db/migrations/committed/000001.sql
@@ -1,5 +1,5 @@
 --! Previous: -
---! Hash: sha1:e6bd89aa12b755d5cbf4ffea0d60e949107e9e05
+--! Hash: sha1:c8ccaecea92c2b3d0693254eaff28a8daea76e85
 
 drop schema if exists app_public cascade;
 
@@ -174,7 +174,7 @@ comment on function app_public.current_user_id() is
 
 create table app_public.users (
   id uuid primary key default gen_random_uuid(),
-  username citext not null unique check(length(username) >= 2 and length(username) <= 24 and username ~ '^[a-zA-Z]([a-zA-Z0-9][_]?)+$'),
+  username citext not null unique check(length(username) >= 2 and length(username) <= 24 and username ~ '^[a-zA-Z]([_]?[a-zA-Z0-9])+$'),
   name text,
   avatar_url text check(avatar_url ~ '^https?://[^/]+'),
   is_admin boolean not null default false,

--- a/data/schema.sql
+++ b/data/schema.sql
@@ -113,7 +113,7 @@ CREATE TABLE app_public.users (
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     updated_at timestamp with time zone DEFAULT now() NOT NULL,
     CONSTRAINT users_avatar_url_check CHECK ((avatar_url ~ '^https?://[^/]+'::text)),
-    CONSTRAINT users_username_check CHECK (((length((username)::text) >= 2) AND (length((username)::text) <= 24) AND (username OPERATOR(public.~) '^[a-zA-Z]([a-zA-Z0-9][_]?)+$'::public.citext)))
+    CONSTRAINT users_username_check CHECK (((length((username)::text) >= 2) AND (length((username)::text) <= 24) AND (username OPERATOR(public.~) '^[a-zA-Z]([_]?[a-zA-Z0-9])+$'::public.citext)))
 );
 
 


### PR DESCRIPTION
## Description

Fixes #226; regexp was wrong.

To apply this to your previous starter DB; add a migration such as:

```sql
alter table app_public.users drop constraint users_username_check;

-- BEWARE: this is technically a breaking change, previous usernames that had a
-- trailing underscore will no longer be allowed (e.g. `AB_`). This may prevent
-- migration.
alter table app_public.users add constraint users_username_check check(length(username) >= 2 and length(username) <= 24 and username ~ '^[a-zA-Z]([_]?[a-zA-Z0-9])+$');
```

## Performance impact

None.

## Security impact

None.
