### PR TITLE
fix: remove npx -n usage in favor of cross-env / NODE_OPTIONS

### DIFF
--- a/@app/client/package.json
+++ b/@app/client/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "scripts": {
-    "build": "cd src && cross-env NODE_ENV=production NODE_OPTIONS=\"$NODE_OPTIONS -r @app/config/env\"  next build",
+    "build": "cd src && cross-env NODE_ENV=production NODE_OPTIONS=\"$NODE_OPTIONS -r @app/config/env\" next build",
     "test": "cross-env NODE_ENV=test NODE_OPTIONS=\"$NODE_OPTIONS -r @app/config/env\" jest"
   },
   "dependencies": {

--- a/@app/client/package.json
+++ b/@app/client/package.json
@@ -3,8 +3,8 @@
   "private": true,
   "version": "0.0.0",
   "scripts": {
-    "build": "cd src && cross-env NODE_ENV=production npx --no-install -n \"-r @app/config/env\" next build",
-    "test": "cross-env NODE_ENV=test npx --no-install -n \"-r @app/config/env\" jest"
+    "build": "cd src && cross-env NODE_ENV=production NODE_OPTIONS=\"$NODE_OPTIONS -r @app/config/env\"  next build",
+    "test": "cross-env NODE_ENV=test NODE_OPTIONS=\"$NODE_OPTIONS -r @app/config/env\" jest"
   },
   "dependencies": {
     "@ant-design/icons": "^4.1.0",

--- a/@app/components/package.json
+++ b/@app/components/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc -b",
-    "test": "cross-env NODE_ENV=test npx --no-install -n \"-r @app/config/env\" jest"
+    "test": "cross-env NODE_ENV=test NODE_OPTIONS=\"$NODE_OPTIONS -r @app/config/env\" jest"
   },
   "dependencies": {
     "@ant-design/icons": "^4.1.0",

--- a/@app/config/package.json
+++ b/@app/config/package.json
@@ -6,7 +6,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc",
-    "test": "cross-env NODE_ENV=test npx --no-install -n \"-r @app/config/env\" jest"
+    "test": "cross-env NODE_ENV=test NODE_OPTIONS=\"$NODE_OPTIONS -r @app/config/env\" jest"
   },
   "dependencies": {
     "dotenv": "^8.2.0"

--- a/@app/db/package.json
+++ b/@app/db/package.json
@@ -14,11 +14,11 @@
     "test": "cross-env NODE_ENV=test NODE_OPTIONS=\"$NODE_OPTIONS -r @app/config/env\" jest"
   },
   "dependencies": {
+    "cross-env": "^7.0.2",
     "graphile-migrate": "^1.0.1"
   },
   "devDependencies": {
     "@types/pg": "^7.14.4",
-    "cross-env": "^7.0.2",
     "graphile-worker": "^0.8.1",
     "jest": "^26.6.3",
     "lodash": "^4.17.15",

--- a/@app/db/package.json
+++ b/@app/db/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "scripts": {
-    "gm": "npx --no-install -n \"-r @app/config/env\" graphile-migrate",
+    "gm": "cross-env NODE_OPTIONS=\"$NODE_OPTIONS -r @app/config/env\" graphile-migrate",
     "migrate": "yarn gm migrate",
     "watch": "yarn gm watch",
     "commit": "yarn gm commit",
@@ -11,7 +11,7 @@
     "reset": "yarn gm reset",
     "dump": "yarn gm migrate && yarn gm reset --shadow --erase && yarn gm migrate --shadow --forceActions",
     "wipe-if-demo": "./scripts/wipe-if-demo",
-    "test": "cross-env NODE_ENV=test npx --no-install -n \"-r @app/config/env\" jest"
+    "test": "cross-env NODE_ENV=test NODE_OPTIONS=\"$NODE_OPTIONS -r @app/config/env\" jest"
   },
   "dependencies": {
     "graphile-migrate": "^1.0.1"

--- a/@app/e2e/package.json
+++ b/@app/e2e/package.json
@@ -3,10 +3,10 @@
   "private": true,
   "version": "0.0.0",
   "scripts": {
-    "cy": "npx --no-install -n \"-r @app/config/env\" cypress",
+    "cy": "cross-env NODE_OPTIONS=\"$NODE_OPTIONS -r @app/config/env\" cypress",
     "open": "yarn cy open",
     "run": "yarn cy run",
-    "test": "cross-env NODE_ENV=test npx --no-install -n \"-r @app/config/env\" jest"
+    "test": "cross-env NODE_ENV=test NODE_OPTIONS=\"$NODE_OPTIONS -r @app/config/env\" jest"
   },
   "devDependencies": {
     "@cypress/webpack-preprocessor": "^5.5.0",

--- a/@app/graphql/package.json
+++ b/@app/graphql/package.json
@@ -8,7 +8,7 @@
     "build": "yarn codegen && tsc -b",
     "watch": "yarn codegen --watch",
     "codegen": "graphql-codegen --config codegen.yml",
-    "test": "cross-env NODE_ENV=test npx --no-install -n \"-r @app/config/env\" jest"
+    "test": "cross-env NODE_ENV=test NODE_OPTIONS=\"$NODE_OPTIONS -r @app/config/env\" jest"
   },
   "dependencies": {
     "@apollo/react-common": "^3.1.4",

--- a/@app/lib/package.json
+++ b/@app/lib/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc -b",
-    "test": "cross-env NODE_ENV=test npx --no-install -n \"-r @app/config/env\" jest"
+    "test": "cross-env NODE_ENV=test NODE_OPTIONS=\"$NODE_OPTIONS -r @app/config/env\" jest"
   },
   "dependencies": {
     "@apollo/react-ssr": "^3.1.5",

--- a/@app/server/package.json
+++ b/@app/server/package.json
@@ -6,9 +6,9 @@
     "build": "tsc -b",
     "start": "node -r @app/config/env dist/index.js",
     "dev": "nodemon --signal SIGINT --watch 'dist/**/*.js' -x \"node --inspect=9678 -r @app/config/env -r source-map-support/register\" dist/index.js",
-    "schema:export": "npx --no-install -n \"-r @app/config/env\" ts-node scripts/schema-export.ts",
+    "schema:export": "cross-env NODE_OPTIONS=\"$NODE_OPTIONS -r @app/config/env\" ts-node scripts/schema-export.ts",
     "cloudflare:import": "(echo \"export const cloudflareIps: string[] = [\"; (curl -Ls https://www.cloudflare.com/ips-v4 | sort | sed -e \"s/^/  \\\"/\" -e \"s/$/\\\",/\"); echo \"];\") > src/cloudflare.ts",
-    "test": "cross-env NODE_ENV=test npx --no-install -n \"-r @app/config/env\" jest"
+    "test": "cross-env NODE_ENV=test NODE_OPTIONS=\"$NODE_OPTIONS -r @app/config/env\" jest"
   },
   "dependencies": {
     "@app/client": "0.0.0",

--- a/@app/worker/package.json
+++ b/@app/worker/package.json
@@ -3,12 +3,12 @@
   "private": true,
   "version": "0.0.0",
   "scripts": {
-    "gw": "cd dist && npx --no-install -n \"-r @app/config/env\" graphile-worker",
+    "gw": "cd dist && cross-env NODE_OPTIONS=\"$NODE_OPTIONS -r @app/config/env\" graphile-worker",
     "build": "tsc -b",
     "start": "yarn gw",
-    "dev": "cd dist && npx --no-install -n \"-r @app/config/env --inspect=9757\" graphile-worker --watch",
+    "dev": "cd dist && cross-env NODE_OPTIONS=\"$NODE_OPTIONS -r @app/config/env --inspect=9757\" graphile-worker --watch",
     "install-db-schema": "mkdirp dist && yarn gw --schema-only",
-    "test": "cross-env NODE_ENV=test npx --no-install -n \"-r @app/config/env\" jest"
+    "test": "cross-env NODE_ENV=test NODE_OPTIONS=\"$NODE_OPTIONS -r @app/config/env\" jest"
   },
   "dependencies": {
     "@app/config": "0.0.0",

--- a/@app/worker/package.json
+++ b/@app/worker/package.json
@@ -18,6 +18,7 @@
     "@types/nodemailer": "^6.4.0",
     "aws-sdk": "^2.668.0",
     "chalk": "^4.0.0",
+    "cross-env": "^7.0.2",
     "graphile-worker": "^0.8.1",
     "html-to-text": "^6.0.0",
     "lodash": "^4.17.15",
@@ -26,7 +27,6 @@
     "tslib": "^2.0.1"
   },
   "devDependencies": {
-    "cross-env": "^7.0.2",
     "jest": "^26.6.3",
     "mkdirp": "^1.0.4"
   }

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -86,7 +86,7 @@ function main() {
       [
         {
           name: "jest",
-          command: `npx --no-install -n \"--inspect=9876\" jest -i ${watchMode}`,
+          command: `cross-env NODE_OPTIONS=\"--inspect=9876\" jest -i ${watchMode}`,
           prefixColor: "greenBright",
         },
         {


### PR DESCRIPTION
## Description

On cloning this repo and following instructions I encountered errors saying `-n` is no longer supported in `npx`.

![image](https://user-images.githubusercontent.com/1537615/104084579-57c1aa00-5216-11eb-8f86-ccde022ec116.png)

It seems that my version of `npx` is too old to work correctly. I normally use [`fnm`](https://github.com/Schniz/fnm) to manage Node versions and don't use `npm` or `npx` too often so I hadn't noticed this.

More detail: I've installed Node `15.5.1` using `fnm`, this installs `npm@7.3.0` and `npx@7.3.0`, I searched online but I don't see any matrix mapping `npm version -> npx version` anywhere, maybe `fnm` is doing something incorrect by using the same version as `npm`.

This could be mitigated for other users by using `NODE_OPTIONS` instead of `npx`.

## Performance impact

Possibly slightly better perf 🤷‍♂️ , most of these commands were already using `cross-env`.

## Security impact

None.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [x] I've added tests for the new feature, and `yarn test` passes.
- [x] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] If this is a breaking change I've explained why.
