### PR TITLE
fix: remove 'sign in' link from sign in page

### DIFF
--- a/@app/components/src/SharedLayout.tsx
+++ b/@app/components/src/SharedLayout.tsx
@@ -120,6 +120,9 @@ export function SharedLayout({
     Router.events.on("routeChangeComplete", reset);
     Router.push("/");
   }, [client, logout]);
+  const forbidsLoggedIn = forbidWhen & AuthRestrict.LOGGED_IN;
+  const forbidsLoggedOut = forbidWhen & AuthRestrict.LOGGED_OUT;
+  const forbidsNotAdmin = forbidWhen & AuthRestrict.NOT_ADMIN;
   const renderChildren = (props: SharedLayoutChildProps) => {
     const inner =
       props.error && !props.loading && !noHandleErrors ? (
@@ -133,9 +136,6 @@ export function SharedLayout({
       ) : (
         children
       );
-    const forbidsLoggedIn = forbidWhen & AuthRestrict.LOGGED_IN;
-    const forbidsLoggedOut = forbidWhen & AuthRestrict.LOGGED_OUT;
-    const forbidsNotAdmin = forbidWhen & AuthRestrict.NOT_ADMIN;
     if (
       data &&
       data.currentUser &&
@@ -264,7 +264,7 @@ export function SharedLayout({
                   </Warn>
                 </span>
               </Dropdown>
-            ) : (
+            ) : forbidsLoggedIn ? null : (
               <Link href={`/login?next=${encodeURIComponent(currentUrl)}`}>
                 <a data-cy="header-login-button">Sign in</a>
               </Link>

--- a/@app/e2e/cypress/integration/login.spec.ts
+++ b/@app/e2e/cypress/integration/login.spec.ts
@@ -15,6 +15,7 @@ context("Login", () => {
     });
     cy.visit(Cypress.env("ROOT_URL") + "/login");
     cy.getCy("loginpage-button-withusername").click();
+    cy.getCy("header-login-button").should("not.exist"); // No login button on login page
 
     // Action
     cy.getCy("loginpage-input-username").type("testuser");
@@ -46,7 +47,7 @@ context("Login", () => {
     // Assertion
     cy.contains("Incorrect username or passphrase").should("exist");
     cy.url().should("equal", Cypress.env("ROOT_URL") + "/login"); // Should be on login page still
-    cy.getCy("header-login-button").should("exist"); // Should not be logged in
+    cy.getCy("header-login-button").should("not.exist"); // No login button on login page
     cy.getCy("layout-dropdown-user").should("not.exist"); // Should not be logged in
     cy.getCy("layout-dropdown-user").should("not.exist"); // Should not be logged in
 

--- a/@app/e2e/cypress/integration/register_account.spec.ts
+++ b/@app/e2e/cypress/integration/register_account.spec.ts
@@ -33,6 +33,7 @@ context("RegisterAccount", () => {
     it("enables account creation", () => {
       // Setup
       cy.visit(Cypress.env("ROOT_URL") + "/register");
+      cy.getCy("header-login-button").should("not.exist"); // No login button on register page
 
       // Action
       cy.getCy("registerpage-input-name").type("Test User");
@@ -44,7 +45,8 @@ context("RegisterAccount", () => {
 
       // Assertions
       cy.url().should("equal", Cypress.env("ROOT_URL") + "/"); // Should be on homepage
-      cy.getCy("header-login-button").should("not.exist"); // Should be logged in
+      cy.getCy("header-login-button").should("not.exist");
+      cy.getCy("layout-dropdown-user").should("contain", "Test User"); // Should be logged in
     });
 
     it("prevents creation if username is in use", () => {
@@ -62,7 +64,7 @@ context("RegisterAccount", () => {
 
       // Assertions
       cy.contains("account with this username").should("exist");
-      cy.getCy("header-login-button").should("exist"); // Should be logged in
+      cy.getCy("header-login-button").should("not.exist"); // No login button on register page
     });
   });
 });


### PR DESCRIPTION
## Description

Fixes #231; removes Sign in link from sign in, registration, forgot password, and any other page that forbids you to be logged in.

## Performance impact

Negligible.

## Security impact

None known.
