### PR TITLE
fix(graphiql): use origin check to bypass CSRF

### DIFF
--- a/@app/server/src/middleware/installCSRFProtection.ts
+++ b/@app/server/src/middleware/installCSRFProtection.ts
@@ -17,7 +17,8 @@ export default (app: Express) => {
     if (
       req.method === "POST" &&
       req.path === "/graphql" &&
-      req.headers.referer === `${process.env.ROOT_URL}/graphiql`
+      (req.headers.referer === `${process.env.ROOT_URL}/graphiql` ||
+        req.headers.origin === process.env.ROOT_URL)
     ) {
       // Bypass CSRF for GraphiQL
       next();


### PR DESCRIPTION
## Description

In latest Chrome the `Referer` header is no longer being sent from GraphiQL. However, it is [sufficient to check the Origin header for CSRF protection](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#verifying-origin-with-standard-headers) so we can skip the CSRF middleware if the Origin header matches.

## Performance impact

Negligible.

## Security impact

Warrants checking, but believed to be safe.
