### PR TITLE
fix(compat): fix CSP connect-src for Safari; force SSL option

### DIFF
--- a/@app/server/src/app.ts
+++ b/@app/server/src/app.ts
@@ -107,6 +107,9 @@ export async function makeApp({
   await middleware.installCSRFProtection(app);
   await middleware.installPassport(app);
   await middleware.installLogging(app);
+  if (process.env.FORCE_SSL) {
+    await middleware.installForceSSL(app);
+  }
   // These are our assets: images/etc; served out of the /@app/server/public folder (if present)
   await middleware.installSharedStatic(app);
   if (isTest || isDev) {

--- a/@app/server/src/middleware/index.ts
+++ b/@app/server/src/middleware/index.ts
@@ -2,6 +2,7 @@ import installCSRFProtection from "./installCSRFProtection";
 import installCypressServerCommand from "./installCypressServerCommand";
 import installDatabasePools from "./installDatabasePools";
 import installErrorHandler from "./installErrorHandler";
+import installForceSSL from "./installForceSSL";
 import installHelmet from "./installHelmet";
 import installLogging from "./installLogging";
 import installPassport from "./installPassport";
@@ -17,6 +18,7 @@ export {
   installCypressServerCommand,
   installDatabasePools,
   installErrorHandler,
+  installForceSSL,
   installHelmet,
   installLogging,
   installPassport,

--- a/@app/server/src/middleware/installForceSSL.ts
+++ b/@app/server/src/middleware/installForceSSL.ts
@@ -1,0 +1,16 @@
+import { Express } from "express";
+
+export default (app: Express) => {
+  if (!process.env.ROOT_URL || !process.env.ROOT_URL.startsWith("https://")) {
+    throw new Error(
+      "Invalid configuration - FORCE_SSL is enabled, but ROOT_URL doesn't start with https://"
+    );
+  }
+  app.use((req, res, next) => {
+    if (req.protocol !== "https") {
+      return res.redirect(`${process.env.ROOT_URL}${req.path}`);
+    } else {
+      return next();
+    }
+  });
+};

--- a/@app/server/src/middleware/installForceSSL.ts
+++ b/@app/server/src/middleware/installForceSSL.ts
@@ -8,9 +8,15 @@ export default (app: Express) => {
   }
   app.use((req, res, next) => {
     if (req.protocol !== "https") {
-      return res.redirect(`${process.env.ROOT_URL}${req.path}`);
+      if (req.method === "GET" || req.method === "HEAD") {
+        res.redirect(`${process.env.ROOT_URL}${req.path}`);
+      } else {
+        res
+          .status(405)
+          .send(`'${req.method}' requests may only be performed over HTTPS.`);
+      }
     } else {
-      return next();
+      next();
     }
   });
 };

--- a/@app/server/src/middleware/installHelmet.ts
+++ b/@app/server/src/middleware/installHelmet.ts
@@ -1,6 +1,13 @@
 import { Express } from "express";
 import helmet from "helmet";
 
+const tmpRootUrl = process.env.ROOT_URL;
+
+if (!tmpRootUrl || typeof tmpRootUrl !== "string") {
+  throw new Error("Envvar ROOT_URL is required.");
+}
+const ROOT_URL = tmpRootUrl;
+
 const isDevOrTest =
   process.env.NODE_ENV === "development" || process.env.NODE_ENV === "test";
 
@@ -15,6 +22,13 @@ export default function installHelmet(app: Express) {
               directives: {
                 ...helmet.contentSecurityPolicy.getDefaultDirectives(),
                 "script-src": ["'self'", "'unsafe-eval'"],
+                "connect-src": [
+                  "'self'",
+                  // Safari doesn't allow using wss:// origins as 'self' from
+                  // an https:// page, so we have to translate explicitly for
+                  // it.
+                  ROOT_URL.replace(/^http/, "ws"),
+                ],
               },
             },
           }


### PR DESCRIPTION
## Description

See #237; Safari doesn't seem to support `connect-src 'self'` referring to websocket protocol for websockets... So we have to list the full URL.

## Performance impact

Negligible.

## Security impact

There shouldn't be any, but it does relate to CSP.