### PR TITLE
docs(db): describe role concept

### DIFF
--- a/@app/db/README.md
+++ b/@app/db/README.md
@@ -29,33 +29,33 @@ migration framework (for now at least, Graphile Migrate is still young...)
 
 Graphile Starter uses three roles:
 
-- `DATABASE_OWNER` - this is the role that owns the database (**not** the 
+- `DATABASE_OWNER` - this is the role that owns the database (**not** the
   database cluster, just the individual database); i.e. it's the role that runs
   all the migrations and owns the resulting schemas, tables and functions.
 - `DATABASE_AUTHENTICATOR` - this is the role that PostGraphile connects to the
   database with; it has absolutely minimal permissions (only enough to run the
-  introspection queries, and the ability to "switch to" `DATABASE_VISITOR` below).
-  When a GraphQL request comes in, we connect to the database as
+  introspection queries, and the ability to "switch to" `DATABASE_VISITOR`
+  below). When a GraphQL request comes in, we connect to the database as
   `DATABASE_AUTHENTICATOR` and then start a transaction and evaluate the
   equivalent of `SET LOCAL role TO 'DATABASE_VISITOR'`. You might choose to add
-  more visitor-like roles (such as an admin role), but the maintainer finds
-  that the single role solution tends to be more straightforward and has been
+  more visitor-like roles (such as an admin role), but the maintainer finds that
+  the single role solution tends to be more straightforward and has been
   sufficient for all his needs.
 - `DATABASE_VISITOR` - this is the role that the SQL generated from GraphQL
   queries runs as, it's what the vast majority of your `GRANT`s will reference
-  and the row level security policies will apply to. It represents both logged in
-  AND logged out users to your GraphQL API - it's assumed that your Row Level
+  and the row level security policies will apply to. It represents both logged
+  in AND logged out users to your GraphQL API - it's assumed that your Row Level
   Security policies will deferentiate between these states (and any other
   "application roles" the user may have) to determine what they are permitted to
   do.
 
 The `DATABASE_OWNER` role is also used for certain "elevated privilege"
 operations such as login and user registration. Note that `SECURITY DEFINER`
-functions adopt the security level of the role that defined the function
-(as opposed to `SECURITY INVOKER` which uses the security of the role that
-is invoking the function), so you should therefore **make sure to create all
+functions adopt the security level of the role that defined the function (as
+opposed to `SECURITY INVOKER` which uses the security of the role that is
+invoking the function), so you should therefore **make sure to create all
 schema, tables, etc. with the `DATABASE_OWNER` in all environments** (local,
-dev, production), not with your own user role nor the default superuser role 
+dev, production), not with your own user role nor the default superuser role
 (often named `postgres`). This ensures that the system behaves as expected when
 graduating from your local dev environment to hosted database systems in
 production.

--- a/@app/db/README.md
+++ b/@app/db/README.md
@@ -27,16 +27,35 @@ migration framework (for now at least, Graphile Migrate is still young...)
 
 ## Database Roles
 
-We're using the concept of two main database roles: the `DATABASE_OWNER` and the
-`DATABASE_VISITOR`. The `DATABASE_VISITOR` is used for all incoming requests and
-changes its role according to the requesting client/user to act with the correct
-privileges.
+Graphile Starter uses three roles:
 
-The `DATABASE_OWNER` is the internal system user and has access to all resources
-in our schemas. The initial migration schema assumes that the `DATABASE_OWNER` is
-actually the [user that created the database resources (hence, the owner)](https://www.postgresql.org/docs/current/ddl-priv.html).
+- `DATABASE_OWNER` - this is the role that owns the database (**not** the 
+  database cluster, just the individual database); i.e. it's the role that runs
+  all the migrations and owns the resulting schemas, tables and functions.
+- `DATABASE_AUTHENTICATOR` - this is the role that PostGraphile connects to the
+  database with; it has absolutely minimal permissions (only enough to run the
+  introspection queries, and the ability to "switch to" `DATABASE_VISITOR` below).
+  When a GraphQL request comes in, we connect to the database as
+  `DATABASE_AUTHENTICATOR` and then start a transaction and evaluate the
+  equivalent of `SET LOCAL role TO 'DATABASE_VISITOR'`. You might choose to add
+  more visitor-like roles (such as an admin role), but the maintainer finds
+  that the single role solution tends to be more straightforward and has been
+  sufficient for all his needs.
+- `DATABASE_VISITOR` - this is the role that the SQL generated from GraphQL
+  queries runs as, it's what the vast majority of your `GRANT`s will reference
+  and the row level security policies will apply to. It represents both logged in
+  AND logged out users to your GraphQL API - it's assumed that your Row Level
+  Security policies will deferentiate between these states (and any other
+  "application roles" the user may have) to determine what they are permitted to
+  do.
 
-You should therefore make sure to create all schema, tables, etc. with the
-`DATABASE_OWNER` in all environments (local, dev, prod), not with the default
-`postgres` superuser. This ensures that the system behaves as expected when
-graduating from your local dev environment to hosted database systems in production.
+The `DATABASE_OWNER` role is also used for certain "elevated privilege"
+operations such as login and user registration. Note that `SECURITY DEFINER`
+functions adopt the security level of the role that defined the function
+(as opposed to `SECURITY INVOKER` which uses the security of the role that
+is invoking the function), so you should therefore **make sure to create all
+schema, tables, etc. with the `DATABASE_OWNER` in all environments** (local,
+dev, production), not with your own user role nor the default superuser role 
+(often named `postgres`). This ensures that the system behaves as expected when
+graduating from your local dev environment to hosted database systems in
+production.

--- a/@app/db/README.md
+++ b/@app/db/README.md
@@ -24,3 +24,19 @@ and SQL knowledge to work well.
 
 If you're not very comfortable with SQL then we recommend you use an alternative
 migration framework (for now at least, Graphile Migrate is still young...)
+
+## Database Roles
+
+We're using the concept of two main database roles: the `DATABASE_OWNER` and the
+`DATABASE_VISITOR`. The `DATABASE_VISITOR` is used for all incoming requests and
+changes its role according to the requesting client/user to act with the correct
+privileges.
+
+The `DATABASE_OWNER` is the internal system user and has access to all resources
+in our schemas. The initial migration schema assumes that the `DATABASE_OWNER` is
+actually the [user that created the database resources (hence, the owner)](https://www.postgresql.org/docs/current/ddl-priv.html).
+
+You should therefore make sure to create all schema, tables, etc. with the
+`DATABASE_OWNER` in all environments (local, dev, prod), not with the default
+`postgres` superuser. This ensures that the system behaves as expected when
+graduating from your local dev environment to hosted database systems in production.


### PR DESCRIPTION
Highlight that the `DATABASE_OWNER` must actually be the *owner* to work as expected.

This misunderstanding on my end caused quite some delay in my project's rollout, therefore
I figured that others might also run into this issue.

## Description

The issue occured to me when I created the initial schema with my personal postgres user,
not with the `DATABASE_OWNER` role. Therefore, nothing in the private schema, as well as
in the graphile_worker schema was accessable.

Here is an example of another person who probably had a similar issue: https://discord.com/channels/489127045289476126/498852330754801666/779378725946130462

<!-- If this PR adds a feature, what does it add and what was the motivation for it? -->
<!-- If this PR fixes an issue, what is the issue? -->
<!-- Please link to the relevant GitHub issues/Discord discussion/etc as appropriate -->

## Performance impact

n/a

## Security impact

n/a

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
