### PR TITLE
chore(docker): upgrade to Node 14 base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12
+FROM node:14
 
 # The node image comes with a base non-root 'node' user which this Dockerfile
 # gives sudo access. However, for Linux, this user's GID/UID must match your local


### PR DESCRIPTION
Only Node 14+ supports optional chaining which is required by `postgraphile`.

This fixes https://github.com/graphile/starter/issues/247