### PR TITLE
Migration filename update in Readme

### DIFF
--- a/@app/db/migrations/README.md
+++ b/@app/db/migrations/README.md
@@ -6,7 +6,7 @@ implementing your own migrations:
 
 https://github.com/graphile/migrate/blob/main/README.md
 
-The main file you'll be working with is `current.sql`.
+The main file you'll be working with is `1-current.sql`.
 
 ## afterReset.sql
 
@@ -15,7 +15,7 @@ currently grants permissions to the relevant roles and creates the required
 extensions. It's expected that this is ran with database superuser privileges as
 normal users often don't have sufficient permissions to install extensions.
 
-## current.sql
+## current/1-current.sql
 
 This is where your new database changes go. They need to be idempotent (for
 details read the README above). The `yarn start` command will automatically
@@ -51,7 +51,7 @@ with
 yarn db commit
 ```
 
-This will call `graphile-migrate commit` which involves moving `current.sql`
+This will call `graphile-migrate commit` which involves moving `1-current.sql`
 into the `committed` folder, and hashing it to prevent later modifications
 (which should instead be done with additional migrations).
 


### PR DESCRIPTION
The migration readme retained the old location and name of the migration file `current.sql`,
which had been moved and renamed to `1-current.sql`. This has been corrected.


## Description

<!-- If this PR adds a feature, what does it add and what was the motivation for it? -->
<!-- If this PR fixes an issue, what is the issue? -->
<!-- Please link to the relevant GitHub issues/Discord discussion/etc as appropriate -->

## Performance impact

<!-- Detail any impact on performance of this PR, or put 'unknown' if not known -->

## Security impact

<!-- Detail any impact on security of this PR, or put 'unknown' if not known -->

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [x] I've added tests for the new feature, and `yarn test` passes.
- [x] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
