### PR TITLE
fix: `/settings` page - incorrect errorcode checked

### DIFF
--- a/@app/client/src/pages/settings/index.tsx
+++ b/@app/client/src/pages/settings/index.tsx
@@ -84,7 +84,7 @@ function ProfileSettingsForm({
         setSuccess(true);
       } catch (e) {
         const errcode = getCodeFromError(e);
-        if (errcode === "23505") {
+        if (errcode === "NUNIQ") {
           form.setFields([
             {
               name: "username",


### PR DESCRIPTION
## Description

On the `/settings` page the error for the username being unique is not currently being handled correctly. 

The check on errors coming back from Apollo is checking for the error code `23505` but it is actually being rewritten as `NUNIQ` and so does not match. 

The error codes are stated in the [error_codes.md](/graphile/starter/blob/main/docs/error_codes.md) file, replaced using the [handleErrors.ts](/graphile/starter/blob/main/@app/server/src/utils/handleErrors.ts) file and I can also confirm I am physically seeing `NUNIQ` being returned when using the starter.

<!-- If this PR adds a feature, what does it add and what was the motivation for it? -->
<!-- If this PR fixes an issue, what is the issue? -->
<!-- Please link to the relevant GitHub issues/Discord discussion/etc as appropriate -->

## Performance impact

None

<!-- Detail any impact on performance of this PR, or put 'unknown' if not known -->

## Security impact

None

<!-- Detail any impact on security of this PR, or put 'unknown' if not known -->

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
