### PR TITLE
fix: make username sanitization case-insensitive (#284)

### DIFF
--- a/@app/db/migrations/committed/000001.sql
+++ b/@app/db/migrations/committed/000001.sql
@@ -1,5 +1,5 @@
 --! Previous: -
---! Hash: sha1:eaf2866060caa0bba319236017c15a40d37a7815
+--! Hash: sha1:fed7686b198e84812a6712d8b4da5add87a5f38f
 
 --! split: 0001-reset.sql
 /*
@@ -1369,10 +1369,11 @@ begin
   where not exists(
     select 1
     from app_public.users
-    where users.username = (
+    -- Compare using lowercase, as username column is case-insensitive
+    where lower(users.username) = (
       case
-      when i = 0 then v_username
-      else v_username || i::text
+      when i = 0 then lower(v_username)
+      else lower(v_username) || i::text
       end
     )
   )

--- a/data/schema.sql
+++ b/data/schema.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 13.4 (Ubuntu 13.4-0ubuntu0.21.04.1)
--- Dumped by pg_dump version 13.4 (Ubuntu 13.4-0ubuntu0.21.04.1)
+-- Dumped from database version 13rc1 (Debian 13~rc1-1.pgdg100+1)
+-- Dumped by pg_dump version 13.4 (Debian 13.4-3)
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -451,10 +451,11 @@ begin
   where not exists(
     select 1
     from app_public.users
-    where users.username = (
+    -- Compare using lowercase, as username column is case-insensitive
+    where lower(users.username) = (
       case
-      when i = 0 then v_username
-      else v_username || i::text
+      when i = 0 then lower(v_username)
+      else lower(v_username) || i::text
       end
     )
   )
@@ -2497,7 +2498,7 @@ GRANT USAGE ON SCHEMA app_public TO graphile_starter_visitor;
 -- Name: SCHEMA public; Type: ACL; Schema: -; Owner: -
 --
 
-REVOKE ALL ON SCHEMA public FROM postgres;
+REVOKE ALL ON SCHEMA public FROM ark_starter;
 REVOKE ALL ON SCHEMA public FROM PUBLIC;
 GRANT ALL ON SCHEMA public TO graphile_starter;
 GRANT USAGE ON SCHEMA public TO graphile_starter_visitor;


### PR DESCRIPTION
## Description

Fixes #284, makes username sanitization case-insensitive to avoid potential conflicts when creating account using oauth providers.

## Performance impact

Should be minimal (using lower() 3x in sanitization loop, potentially could be optimized by only running it once and assigning to a variable, is it worth it?

## Security impact

None.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.
