### PR TITLE
Add cypress test for subscription update of user verification

### DIFF
--- a/@app/components/src/SharedLayout.tsx
+++ b/@app/components/src/SharedLayout.tsx
@@ -254,7 +254,10 @@ export function SharedLayout({
                   <Avatar>
                     {(data.currentUser.name && data.currentUser.name[0]) || "?"}
                   </Avatar>
-                  <Warn okay={data.currentUser.isVerified}>
+                  <Warn
+                    okay={data.currentUser.isVerified}
+                    data-cy="header-unverified-warning"
+                  >
                     <span style={{ marginLeft: 8, marginRight: 8 }}>
                       {data.currentUser.name}
                     </span>

--- a/@app/e2e/cypress/integration/subscriptions.spec.ts
+++ b/@app/e2e/cypress/integration/subscriptions.spec.ts
@@ -1,0 +1,74 @@
+/// <reference types="Cypress" />
+
+export {};
+
+const PASSWORD = "MyPassword1";
+
+context("Subscriptions", () => {
+  beforeEach(() => cy.serverCommand("clearTestUsers"));
+
+  it("can log in; current user subscription works", () => {
+    // Setup
+    cy.serverCommand("createUser", {
+      username: "testuser",
+      name: "Test User",
+      verified: false,
+      password: PASSWORD,
+    });
+    cy.visit(Cypress.env("ROOT_URL") + "/login");
+    cy.getCy("loginpage-button-withusername").click();
+    cy.getCy("header-login-button").should("not.exist"); // No login button on login page
+
+    // Action
+    cy.getCy("loginpage-input-username").type("testuser");
+    cy.getCy("loginpage-input-password").type(PASSWORD);
+    cy.getCy("loginpage-button-submit").click();
+
+    // Assertion
+    cy.url().should("equal", Cypress.env("ROOT_URL") + "/"); // Should be on homepage
+    cy.getCy("header-login-button").should("not.exist"); // Should be logged in
+    cy.getCy("layout-dropdown-user").should("contain", "Test User"); // Should be logged in
+
+    // Subscription
+    cy.getCy("header-unverified-warning").should("exist");
+    cy.wait(1000); // allow the websocket to reconnect
+    cy.serverCommand("verifyUser");
+    cy.getCy("header-unverified-warning").should("not.exist");
+  });
+
+  it("can start on an already logged-in session; current user subscription works", () => {
+    // Setup
+    cy.login({ next: "/", verified: false });
+
+    // Subscription
+    cy.getCy("header-unverified-warning").should("exist");
+    cy.wait(1000); // allow the websocket to reconnect
+    cy.serverCommand("verifyUser");
+    cy.getCy("header-unverified-warning").should("not.exist");
+  });
+
+  it("can register; current user subscription works", () => {
+    // Setup
+    cy.visit(Cypress.env("ROOT_URL") + "/register");
+    cy.getCy("header-login-button").should("not.exist"); // No login button on register page
+
+    // Action
+    cy.getCy("registerpage-input-name").type("Test User");
+    cy.getCy("registerpage-input-username").type("testuser");
+    cy.getCy("registerpage-input-email").type("test.user@example.com");
+    cy.getCy("registerpage-input-password").type("Really Good Password");
+    cy.getCy("registerpage-input-password2").type("Really Good Password");
+    cy.getCy("registerpage-submit-button").click();
+
+    // Assertions
+    cy.url().should("equal", Cypress.env("ROOT_URL") + "/"); // Should be on homepage
+    cy.getCy("header-login-button").should("not.exist");
+    cy.getCy("layout-dropdown-user").should("contain", "Test User"); // Should be logged in
+
+    // Subscription
+    cy.getCy("header-unverified-warning").should("exist");
+    cy.wait(1000); // allow the websocket to reconnect
+    cy.serverCommand("verifyUser");
+    cy.getCy("header-unverified-warning").should("not.exist");
+  });
+});

--- a/@app/e2e/cypress/support/commands.ts
+++ b/@app/e2e/cypress/support/commands.ts
@@ -91,6 +91,15 @@ function serverCommand(
   verification_token: string | null;
 }>;
 
+/**
+ * Marks the given user as verified. Used for testing live user subscription
+ * updates.
+ */
+function serverCommand(
+  command: "verifyUser",
+  payload?: { username?: string }
+): Chainable<{ success: true }>;
+
 // The actual implementation of the 'serverCommand' function.
 function serverCommand(command: string, payload?: any): any {
   const url = `${Cypress.env(

--- a/@app/server/src/middleware/installCypressServerCommand.ts
+++ b/@app/server/src/middleware/installCypressServerCommand.ts
@@ -225,6 +225,13 @@ async function runCommand(
     const { email = "testuser@example.com" } = payload;
     const userEmailSecrets = await getUserEmailSecrets(rootPgPool, email);
     return userEmailSecrets;
+  } else if (command === "verifyUser") {
+    const { username = "testuser" } = payload;
+    await rootPgPool.query(
+      "update app_public.users SET is_verified = TRUE where username = $1",
+      [username]
+    );
+    return { success: true };
   } else {
     throw new Error(`Command '${command}' not understood.`);
   }


### PR DESCRIPTION
## Description

<!-- If this PR adds a feature, what does it add and what was the motivation for it? -->
Adds a test to confirm that the current user subscription used for displaying validation status correctly updates the UI when database modifications are made.
<!-- If this PR fixes an issue, what is the issue? -->
<!-- Please link to the relevant GitHub issues/Discord discussion/etc as appropriate -->

## Performance impact

<!-- Detail any impact on performance of this PR, or put 'unknown' if not known -->
None.

## Security impact

<!-- Detail any impact on security of this PR, or put 'unknown' if not known -->
None.

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

N/A - this is a test-only change.

- [ ] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
