### PR TITLE
Mark protocol-relative urls as unsafe in client-side auth redirects

### DIFF
--- a/@app/client/src/pages/login.tsx
+++ b/@app/client/src/pages/login.tsx
@@ -33,7 +33,8 @@ interface LoginProps {
 }
 
 export function isSafe(nextUrl: string | null) {
-  return (nextUrl && nextUrl[0] === "/") || false;
+  // Prevent protocol-relative URLs - test for `//foo.bar`
+  return (nextUrl && nextUrl[0] === "/" && nextUrl[1] !== "/") || false;
 }
 
 /**


### PR DESCRIPTION
Fixes #320