### PR TITLE
Add types property to @app/lib package.json

### DIFF
--- a/@app/lib/package.json
+++ b/@app/lib/package.json
@@ -2,6 +2,7 @@
   "name": "@app/lib",
   "version": "0.0.0",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc -b",
     "test": "cross-env NODE_ENV=test NODE_OPTIONS=\"${NODE_OPTIONS:-} -r @app/config/env\" jest"


### PR DESCRIPTION
Fixes issue where @app/lib cannot be imported in other monorepo packages due to a type resolution error.