### PR TITLE
Fix docker yarn commands & dockerfile start command

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ This project is designed to work with `yarn`. If you don't have `yarn`
 installed, you can install it with `npm install -g yarn`. The Docker setup
 already has `yarn` & `npm` installed and configured.
 
-To get started, please run:
+To get started, please run `yarn`, followed by:
 
 | Local mode   | OR  | Docker mode                     |
 | ------------ | :-: | ------------------------------- |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
     depends_on:
       - db
     #* Overrides default command so things don't shut down after the process ends.
-    command: yarn start
+    command: sh -c "yarn && yarn start"
 
   # extends server, is made for live developing
   dev:

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "lib": "yarn workspace @app/lib",
     "server": "yarn workspace @app/server",
     "worker": "yarn workspace @app/worker",
-    "docker": "yarn --cwd ./docker",
-    "docker-compose": "yarn --cwd ./docker compose"
+    "docker": "yarn workspace docker-helpers",
+    "docker-compose": "yarn workspace docker-helpers compose"
   },
   "author": "Benjie Gillam <code@benjiegillam.com>",
   "license": "SEE LICENSE IN LICENSE.md",


### PR DESCRIPTION
Resolves the following issues:
- `yarn docker start` would run `yarn start` in the top-level directory rather than using the docker-helpers workspace
- The docker container created by `docker compose up` would fail to launch because yarn 3.x requires an initial `yarn` invocation to succeed before any scripts can be run.