### PR TITLE
Run a yarn install prior to `yarn setup` call in docker setup

### DIFF
--- a/docker/scripts/yarn-setup.js
+++ b/docker/scripts/yarn-setup.js
@@ -72,6 +72,16 @@ ROOT_DATABASE_URL=postgres://postgres:${password}@db/postgres
     "chmod o+rwx /var/run/docker.sock && chown -R node /work/node_modules /work/@app/*/node_modules",
   ]);
 
+  // Run a yarn install to allow yarn commands to run
+  runSync(yarnCmd, [
+    "compose",
+    "run",
+    "-e",
+    `PROJECT_NAME=${projectName}`,
+    "server",
+    "yarn",
+  ]);
+
   // Run setup as normal
   runSync(yarnCmd, [
     "compose",


### PR DESCRIPTION
Fixes an issue related to the yarn 3 upgrade where a yarn install is required prior to any yarn scripts being run.