### PR TITLE
Update yarn-setup.js to also set group

### DIFF
--- a/docker/scripts/yarn-setup.js
+++ b/docker/scripts/yarn-setup.js
@@ -61,7 +61,8 @@ ROOT_DATABASE_URL=postgres://postgres:${password}@db/postgres
   runSync(yarnCmd, ["down"]);
   runSync(yarnCmd, ["db:up"]);
 
-  // Fix permissions
+  // Fix permissions as the node_modules directories might be mounted docker
+  // volumes and they are in that case owned by root
   runSync(yarnCmd, [
     "compose",
     "run",
@@ -69,7 +70,7 @@ ROOT_DATABASE_URL=postgres://postgres:${password}@db/postgres
     "sudo",
     "bash",
     "-c",
-    "chmod o+rwx /var/run/docker.sock && chown -R node /work/node_modules /work/@app/*/node_modules",
+    "chmod o+rwx /var/run/docker.sock && chown -R node:node /work/node_modules /work/@app/*/node_modules",
   ]);
 
   // Run a yarn install to allow yarn commands to run


### PR DESCRIPTION
When fixing the permissions of node_modules mounted from docker volumes also set the group to node. This does not fix a bug, it works just as it is, but it looks strange especially when debugging and one is looking into every possible problem =).

I also updated the comment around it as at first I could not understand why it would be needed in the first place as I thought the dirs would be owned by node if the node_modules dirs were created by yarn run by the node user.

## Description

<!-- If this PR adds a feature, what does it add and what was the motivation for it? -->
<!-- If this PR fixes an issue, what is the issue? -->
<!-- Please link to the relevant GitHub issues/Discord discussion/etc as appropriate -->

## Performance impact

<!-- Detail any impact on performance of this PR, or put 'unknown' if not known -->

## Security impact

<!-- Detail any impact on security of this PR, or put 'unknown' if not known -->

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [ ] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
