### PR TITLE
Run an `ls` command on container start to fix macOS git perms

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,8 +39,7 @@ services:
       - "9757:9757"
     depends_on:
       - db
-    #* Overrides default command so things don't shut down after the process ends.
-    command: sh -c "yarn && yarn start"
+    command: sh -c "./docker/scripts/lsfix.sh && yarn && yarn start"
 
   # extends server, is made for live developing
   dev:
@@ -107,7 +106,7 @@ services:
     depends_on:
       - db
     # Overrides default command so things don't shut down after the process ends.
-    command: sleep infinity
+    command: sh -c "./docker/scripts/lsfix.sh && sleep infinity"
 
   # This runs the database that everything else connects to
   db:

--- a/docker/scripts/lsfix.sh
+++ b/docker/scripts/lsfix.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# We don't understand how this works, but on Mac you get the following error sometimes due to Docker volume ownership issues:
+#     fatal: detected dubious ownership in repository at '/work'
+#     To add an exception for this directory, call: [...]
+# But weirdly, just listing the directory fixes it. 🤷
+ls >/dev/null


### PR DESCRIPTION
Fixes a problem where git commands in the container on macOS failed with a "dubious ownership in repository" error.