### PR TITLE
Fix typo in `ERROR_PROPERTIES_TO_EXPOSE`

### DIFF
--- a/@app/server/src/utils/handleErrors.ts
+++ b/@app/server/src/utils/handleErrors.ts
@@ -11,7 +11,7 @@ const ERROR_PROPERTIES_TO_EXPOSE =
         "severity",
         "detail",
         "hint",
-        "positon",
+        "position",
         "internalPosition",
         "internalQuery",
         "where",


### PR DESCRIPTION
## Description

Changed `positon` to `position` in handleErrors.ts.

This is such a minor change that I've discarded the remainder of the PR template. I hope that's okay!