### PR TITLE
test(helpers): pass client instead of pool; fix typing

### DIFF
--- a/@app/__tests__/helpers.ts
+++ b/@app/__tests__/helpers.ts
@@ -1,6 +1,6 @@
 import { Pool, PoolClient } from "pg";
 
-const pools = {};
+const pools: { [key: string]: Pool } = {};
 
 if (!process.env.TEST_DATABASE_URL) {
   throw new Error("Cannot run tests without a TEST_DATABASE_URL");

--- a/@app/server/__tests__/helpers.ts
+++ b/@app/server/__tests__/helpers.ts
@@ -25,8 +25,8 @@ export async function createUserAndLogIn() {
   const pool = poolFromUrl(process.env.TEST_DATABASE_URL!);
   const client = await pool.connect();
   try {
-    const [user] = await createUsers(pool, 1, true);
-    const session = await createSession(pool, user.id);
+    const [user] = await createUsers(client, 1, true);
+    const session = await createSession(client, user.id);
     return { user, session };
   } finally {
     client.release();


### PR DESCRIPTION
## Description

This fixes passing the `client` to test helpers instead of the pool. It also adds typings to the `pools` cache to allow TS to catch future mismatches.

## Performance impact

Presumably none.

## Security impact

Presumably none.

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [x] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
