### PR TITLE
Don't force HTTPS in local dev

### DIFF
--- a/@app/server/src/middleware/installHelmet.ts
+++ b/@app/server/src/middleware/installHelmet.ts
@@ -8,8 +8,8 @@ if (!tmpRootUrl || typeof tmpRootUrl !== "string") {
 }
 const ROOT_URL = tmpRootUrl;
 
-const isDevOrTest =
-  process.env.NODE_ENV === "development" || process.env.NODE_ENV === "test";
+const isDev = process.env.NODE_ENV === "development";
+const isTest = process.env.NODE_ENV === "test";
 
 export default async function installHelmet(app: Express) {
   const { default: helmet, contentSecurityPolicy } = await import("helmet");
@@ -28,14 +28,23 @@ export default async function installHelmet(app: Express) {
       },
     },
   };
-  if (isDevOrTest) {
-    // Appease TypeScript
-    if (
-      typeof options.contentSecurityPolicy === "boolean" ||
-      !options.contentSecurityPolicy
-    ) {
-      throw new Error(`contentSecurityPolicy must be an object`);
-    }
+  // Appease TypeScript
+  if (
+    typeof options.contentSecurityPolicy === "boolean" ||
+    !options.contentSecurityPolicy
+  ) {
+    throw new Error(`contentSecurityPolicy must be an object`);
+  }
+  if (isDev) {
+    // Disable HSTS in dev so browsers don't cache "always use HTTPS" for localhost
+    options.hsts = false;
+
+    // Remove upgrade-insecure-requests in dev — it causes browsers to upgrade
+    // subresource requests to HTTPS even when the server only speaks HTTP.
+    options.contentSecurityPolicy.directives!["upgrade-insecure-requests"] =
+      null;
+  }
+  if (isDev || isTest) {
     // Dev needs 'unsafe-eval' due to
     // https://github.com/vercel/next.js/issues/14221
     options.contentSecurityPolicy.directives!["script-src"] = [
@@ -43,7 +52,7 @@ export default async function installHelmet(app: Express) {
       "'unsafe-eval'",
     ];
   }
-  if (isDevOrTest || !!process.env.ENABLE_GRAPHIQL) {
+  if (isDev || isTest || !!process.env.ENABLE_GRAPHIQL) {
     // Enables prettier script and SVG icon in GraphiQL
     options.crossOriginEmbedderPolicy = false;
   }


### PR DESCRIPTION
## Description

I found when I cloned Graphile Starter, that my connection to `http://localhost:5678` was being automatically redirected to an `https://` origin and that the frontend's fetches to Next.js build artifacts were also being redirected. These changes enable local development on `http://` origins.