### PR TITLE
PostgreSQL -> 17

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -19,7 +19,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:14
+        image: postgres:17
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
@@ -41,7 +41,7 @@ jobs:
           sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
           wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
           sudo apt-get update
-          sudo apt-get -yqq install postgresql-client-14
+          sudo apt-get -yqq install postgresql-client-17
       - name: Setup
         run: |
           cp .env.ci .env

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -17,7 +17,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:14
+        image: postgres:17
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
@@ -39,7 +39,7 @@ jobs:
           sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
           wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
           sudo apt-get update
-          sudo apt-get -yqq install postgresql-client-14
+          sudo apt-get -yqq install postgresql-client-17
       - name: yarn, lint, build and test
         run: |
           cp .env.ci .env

--- a/.github/workflows/pgrita.yml
+++ b/.github/workflows/pgrita.yml
@@ -12,7 +12,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:14
+        image: postgres:17
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/.github/workflows/production-docker.yml
+++ b/.github/workflows/production-docker.yml
@@ -12,7 +12,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:14
+        image: postgres:17
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
@@ -35,7 +35,7 @@ jobs:
           sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
           wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
           sudo apt-get update
-          sudo apt-get -yqq install postgresql-client-14
+          sudo apt-get -yqq install postgresql-client-17
       - name: setup database
         run: |
           cp .env.ci .env

--- a/.github/workflows/windows-nodejs.yml
+++ b/.github/workflows/windows-nodejs.yml
@@ -24,10 +24,10 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: "16"
-      - name: Start Postgres 14
+      - name: Start Postgres 17
         run: |
-          sc config postgresql-x64-14 start=auto
-          net start postgresql-x64-14
+          sc config postgresql-x64-17 start=auto
+          net start postgresql-x64-17
       - name: Setup environment
         # Windows postgres auth is 'postgres'/'root' - see
         # https://github.com/actions/runner-images/blob/main/images/win/Windows2022-Readme.md#postgresql


### PR DESCRIPTION
Update PostgreSQL to version 17.

Github's `windows-latest` image now uses PostgreSQL 17. Upgrading to PostgreSQL 17 should fix the failing "Windows Node CI" job.