### PR TITLE
Node -> 18

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
 
     services:
       postgres:
@@ -25,7 +25,7 @@ jobs:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: postgres
         ports:
-          - "0.0.0.0:5432:5432"
+          - ":::5432:5432"
         # needed because the postgres container does not provide a healthcheck
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
 
     services:
       postgres:
@@ -23,7 +23,7 @@ jobs:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: postgres
         ports:
-          - "0.0.0.0:5432:5432"
+          - ":::5432:5432"
         # needed because the postgres container does not provide a healthcheck
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 

--- a/.github/workflows/pgrita.yml
+++ b/.github/workflows/pgrita.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
 
     services:
       postgres:
@@ -18,7 +18,7 @@ jobs:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: postgres
         ports:
-          - "0.0.0.0:5432:5432"
+          - ":::5432:5432"
         # needed because the postgres container does not provide a healthcheck
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 

--- a/.github/workflows/production-docker.yml
+++ b/.github/workflows/production-docker.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
 
     services:
       postgres:
@@ -18,7 +18,9 @@ jobs:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: postgres
         ports:
-          - "0.0.0.0:5432:5432"
+          - ":::5432:5432"
+          # docker bridge gateway
+          - "172.17.0.1:5432:5432"
         # needed because the postgres container does not provide a healthcheck
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 

--- a/.github/workflows/windows-nodejs.yml
+++ b/.github/workflows/windows-nodejs.yml
@@ -20,10 +20,10 @@ jobs:
           git config --global core.eol lf
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Use Node.js 16
+      - name: Use Node.js 18
         uses: actions/setup-node@v1
         with:
-          node-version: "16"
+          node-version: "18"
       - name: Start Postgres 14
         run: |
           sc config postgresql-x64-14 start=auto

--- a/production.Dockerfile
+++ b/production.Dockerfile
@@ -7,7 +7,7 @@ ARG TARGET="server"
 ################################################################################
 # Build stage 1 - `yarn build`
 
-FROM node:16-alpine as builder
+FROM node:18-alpine as builder
 # Import our shared args
 ARG NODE_ENV
 ARG ROOT_URL
@@ -30,7 +30,7 @@ RUN yarn run build
 ################################################################################
 # Build stage 2 - COPY the relevant things (multiple steps)
 
-FROM node:16-alpine as clean
+FROM node:18-alpine as clean
 # Import our shared args
 ARG NODE_ENV
 ARG ROOT_URL
@@ -67,7 +67,7 @@ RUN rm -Rf /app/node_modules /app/@app/*/node_modules
 ################################################################################
 # Build stage FINAL - COPY everything, once, and then do a clean `yarn install`
 
-FROM node:16-alpine
+FROM node:18-alpine
 
 EXPOSE $PORT
 WORKDIR /app/

--- a/scripts/_setup_utils.js
+++ b/scripts/_setup_utils.js
@@ -1,5 +1,5 @@
-if (parseInt(process.version.split(".")[0], 10) < 10) {
-  throw new Error("This project requires Node.js >= 10.0.0");
+if (parseInt(process.version.split(".")[0], 18) < 18) {
+  throw new Error("This project requires Node.js >= 18.0.0");
 }
 
 const fsp = require("fs").promises;

--- a/scripts/lib/run.js
+++ b/scripts/lib/run.js
@@ -4,6 +4,7 @@ const runSync = (cmd, args, options = {}) => {
   const result = spawnSync(cmd, args, {
     stdio: ["inherit", "inherit", "inherit"],
     windowsHide: true,
+    shell: process.platform === "win32",
     ...options,
     env: {
       ...process.env,


### PR DESCRIPTION
Update Node to version 18.

- Node 18 changes the resolution of `localhost` to ::1 (ipv6) instead of 127.0.0.1 (ipv4). Tell Docker to map port 5432 (postgres) on ipv6 instead of ipv4.

- Node 18 no longer spawns yarn.cmd with { shell: true } by default, so in `scripts/lib/run.js`, we now set it explicitly if we detect that the OS is win32.
