### PR TITLE
PostgreSQL -> 18

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -19,7 +19,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:17
+        image: postgres:18
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
@@ -41,7 +41,7 @@ jobs:
           sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
           wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
           sudo apt-get update
-          sudo apt-get -yqq install postgresql-client-17
+          sudo apt-get -yqq install postgresql-client-18
       - name: Setup
         run: |
           cp .env.ci .env

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -19,7 +19,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:14
+        image: postgres:17
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
@@ -41,7 +41,7 @@ jobs:
           sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
           wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
           sudo apt-get update
-          sudo apt-get -yqq install postgresql-client-14
+          sudo apt-get -yqq install postgresql-client-17
       - name: Setup
         run: |
           cp .env.ci .env

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -17,7 +17,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:17
+        image: postgres:18
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
@@ -39,7 +39,7 @@ jobs:
           sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
           wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
           sudo apt-get update
-          sudo apt-get -yqq install postgresql-client-17
+          sudo apt-get -yqq install postgresql-client-18
       - name: yarn, lint, build and test
         run: |
           cp .env.ci .env

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -17,7 +17,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:14
+        image: postgres:17
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
@@ -39,7 +39,7 @@ jobs:
           sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
           wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
           sudo apt-get update
-          sudo apt-get -yqq install postgresql-client-14
+          sudo apt-get -yqq install postgresql-client-17
       - name: yarn, lint, build and test
         run: |
           cp .env.ci .env

--- a/.github/workflows/pgrita.yml
+++ b/.github/workflows/pgrita.yml
@@ -12,7 +12,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:14
+        image: postgres:17
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/.github/workflows/pgrita.yml
+++ b/.github/workflows/pgrita.yml
@@ -12,7 +12,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:17
+        image: postgres:18
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/.github/workflows/production-docker.yml
+++ b/.github/workflows/production-docker.yml
@@ -12,7 +12,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:14
+        image: postgres:17
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
@@ -35,7 +35,7 @@ jobs:
           sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
           wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
           sudo apt-get update
-          sudo apt-get -yqq install postgresql-client-14
+          sudo apt-get -yqq install postgresql-client-17
       - name: setup database
         run: |
           cp .env.ci .env

--- a/.github/workflows/production-docker.yml
+++ b/.github/workflows/production-docker.yml
@@ -12,7 +12,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:17
+        image: postgres:18
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
@@ -35,7 +35,7 @@ jobs:
           sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
           wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
           sudo apt-get update
-          sudo apt-get -yqq install postgresql-client-17
+          sudo apt-get -yqq install postgresql-client-18
       - name: setup database
         run: |
           cp .env.ci .env

--- a/.github/workflows/windows-nodejs.yml
+++ b/.github/workflows/windows-nodejs.yml
@@ -24,10 +24,8 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: "16"
-      - name: Start Postgres 17
-        run: |
-          sc config postgresql-x64-17 start=auto
-          net start postgresql-x64-17
+      - name: Install and Start Postgres 18
+        run: choco install postgresql18 -y --params '/Password:root'
       - name: Setup environment
         # Windows postgres auth is 'postgres'/'root' - see
         # https://github.com/actions/runner-images/blob/main/images/win/Windows2022-Readme.md#postgresql

--- a/.github/workflows/windows-nodejs.yml
+++ b/.github/workflows/windows-nodejs.yml
@@ -24,10 +24,10 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: "16"
-      - name: Start Postgres 14
+      - name: Start Postgres 17
         run: |
-          sc config postgresql-x64-14 start=auto
-          net start postgresql-x64-14
+          sc config postgresql-x64-17 start=auto
+          net start postgresql-x64-17
       - name: Setup environment
         # Windows postgres auth is 'postgres'/'root' - see
         # https://github.com/actions/runner-images/blob/main/images/win/Windows2022-Readme.md#postgresql


### PR DESCRIPTION
Update PostgreSQL to version 18.

In light of [graphile/crystal#2752](https://github.com/graphile/crystal/pull/2752), which depends on new PostgreSQL 18 behaviors, it seems advisable for graphile/starter to adopt PostgreSQL 18 in CI and production.

Follows #404